### PR TITLE
Separate mask_color in seg_postprocess function, simplify infer-seg.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# Personal
+.idea
+*.engine
+*.pt
+*.pth
+*.onnx
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 *.pt
 *.pth
 *.onnx
+*.jpg
+*.png
+*.bmp
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/infer-seg.py
+++ b/infer-seg.py
@@ -1,7 +1,5 @@
-from models import TRTModule, TRTProfilerV0  # isort:skip
+from models import TRTModule  # isort:skip
 import argparse
-import os
-import random
 from pathlib import Path
 from typing import List, Tuple, Union
 
@@ -9,89 +7,33 @@ import cv2
 import numpy as np
 import torch
 import torch.nn.functional as F
-from numpy import ndarray
 from torch import Tensor
 
-os.environ['CUDA_MODULE_LOADING'] = 'LAZY'
-
-random.seed(0)
-
-SUFFIXS = ('.bmp', '.dng', '.jpeg', '.jpg', '.mpo', '.png', '.tif', '.tiff',
-           '.webp', '.pfm')
-CLASSES = ('person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus',
-           'train', 'truck', 'boat', 'traffic light', 'fire hydrant',
-           'stop sign', 'parking meter', 'bench', 'bird', 'cat', 'dog',
-           'horse', 'sheep', 'cow', 'elephant', 'bear', 'zebra', 'giraffe',
-           'backpack', 'umbrella', 'handbag', 'tie', 'suitcase', 'frisbee',
-           'skis', 'snowboard', 'sports ball', 'kite', 'baseball bat',
-           'baseball glove', 'skateboard', 'surfboard', 'tennis racket',
-           'bottle', 'wine glass', 'cup', 'fork', 'knife', 'spoon', 'bowl',
-           'banana', 'apple', 'sandwich', 'orange', 'broccoli', 'carrot',
-           'hot dog', 'pizza', 'donut', 'cake', 'chair', 'couch',
-           'potted plant', 'bed', 'dining table', 'toilet', 'tv', 'laptop',
-           'mouse', 'remote', 'keyboard', 'cell phone', 'microwave', 'oven',
-           'toaster', 'sink', 'refrigerator', 'book', 'clock', 'vase',
-           'scissors', 'teddy bear', 'hair drier', 'toothbrush')
-
-COLORS = {
-    cls: [random.randint(0, 255) for _ in range(3)]
-    for i, cls in enumerate(CLASSES)
-}
-
-# the same as yolov8
-MASK_COLORS = np.array([(255, 56, 56), (255, 157, 151), (255, 112, 31),
-                        (255, 178, 29), (207, 210, 49), (72, 249, 10),
-                        (146, 204, 23), (61, 219, 134), (26, 147, 52),
-                        (0, 212, 187), (44, 153, 168), (0, 194, 255),
-                        (52, 69, 147), (100, 115, 255), (0, 24, 236),
-                        (132, 56, 255), (82, 0, 133), (203, 56, 255),
-                        (255, 149, 200), (255, 55, 199)],
-                       dtype=np.float32) / 255.
-
-ALPHA = 0.5
+from infer import SUFFIXS, CLASSES, COLORS, MASK_COLORS, ALPHA
+from infer import letterbox, blob, crop_mask, profile
 
 
-def letterbox(
-    im: ndarray,
-    new_shape: Union[Tuple, List] = (640, 640),
-    color: Union[Tuple, List] = (114, 114, 114)
-) -> Tuple[ndarray, float, Tuple[float, float]]:
-    # Resize and pad image while meeting stride-multiple constraints
-    shape = im.shape[:2]  # current shape [height, width]
-    if isinstance(new_shape, int):
-        new_shape = (new_shape, new_shape)
-
-    # Scale ratio (new / old)
-    r = min(new_shape[0] / shape[0], new_shape[1] / shape[1])
-
-    # Compute padding
-    new_unpad = int(round(shape[1] * r)), int(round(shape[0] * r))
-    dw, dh = new_shape[1] - new_unpad[0], new_shape[0] - new_unpad[
-        1]  # wh padding
-
-    dw /= 2  # divide padding into 2 sides
-    dh /= 2
-
-    if shape[::-1] != new_unpad:  # resize
-        im = cv2.resize(im, new_unpad, interpolation=cv2.INTER_LINEAR)
-    top, bottom = int(round(dh - 0.1)), int(round(dh + 0.1))
-    left, right = int(round(dw - 0.1)), int(round(dw + 0.1))
-    im = cv2.copyMakeBorder(im,
-                            top,
-                            bottom,
-                            left,
-                            right,
-                            cv2.BORDER_CONSTANT,
-                            value=color)  # add border
-    return im, r, (dw, dh)
+def seg_postprocess(
+        data: Tuple[Tensor, Tensor, Tensor, Tensor],
+        shape: Union[Tuple, List]) \
+        -> Tuple[Tensor, Tensor, Tensor, List]:
+    assert len(data) == 4
+    bboxes, scores, labels, masks = data
+    idx = scores > 0
+    bboxes, scores, labels, masks = bboxes[idx], scores[idx], labels[
+        idx], masks[idx]
+    masks = crop_mask(masks, bboxes / 4.)
+    masks = F.interpolate(
+        masks[None], shape, mode='bilinear', align_corners=False)[0]
+    masks = masks.gt_(0.5)[..., None]
+    return bboxes, scores, labels, masks
 
 
-def blob(im: ndarray) -> Tuple[ndarray, ndarray]:
-    seg = im.astype(np.float32) / 255
-    im = im.transpose([2, 0, 1])
-    im = im[np.newaxis, ...]
-    im = np.ascontiguousarray(im).astype(np.float32) / 255
-    return im, seg
+def get_mask_color(labels, masks):
+    cidx = (labels % len(MASK_COLORS)).cpu().numpy()
+    mask_color = torch.tensor(MASK_COLORS[cidx].reshape(-1, 1, 1,
+                                                        3)).to(masks) * ALPHA
+    return masks @ mask_color
 
 
 def main(args):
@@ -129,10 +71,13 @@ def main(args):
         tensor = torch.asarray(tensor, device=device)
         data = Engine(tensor)
 
-        seg_img = torch.asarray(seg_img[dh:H - dh, dw:W - dw, [2, 1, 0]],
-                                device=device)
+        seg_img = torch.asarray(
+            seg_img[dh:H - dh, dw:W - dw, [2, 1, 0]], device=device)
         bboxes, scores, labels, masks = seg_postprocess(data, bgr.shape[:2])
-        mask, mask_color = [m[:, dh:H - dh, dw:W - dw, :] for m in masks]
+        mask_color = get_mask_color(labels, masks)
+        mask, mask_color = [
+            m[:, dh:H - dh, dw:W - dw, :] for m in [masks, mask_color]
+        ]
         inv_alph_masks = (1 - mask * 0.5).cumprod(0)
         mcs = (mask_color * inv_alph_masks).sum(0) * 2
         seg_img = (seg_img * inv_alph_masks[-1] + mcs) * 255
@@ -160,39 +105,6 @@ def main(args):
             cv2.imwrite(str(save_image), draw)
 
 
-def crop_mask(masks: Tensor, bboxes: Tensor) -> Tensor:
-    n, h, w = masks.shape
-    x1, y1, x2, y2 = torch.chunk(bboxes[:, :, None], 4, 1)  # x1 shape(1,1,n)
-    r = torch.arange(w, device=masks.device,
-                     dtype=x1.dtype)[None, None, :]  # rows shape(1,w,1)
-    c = torch.arange(h, device=masks.device,
-                     dtype=x1.dtype)[None, :, None]  # cols shape(h,1,1)
-
-    return masks * ((r >= x1) * (r < x2) * (c >= y1) * (c < y2))
-
-
-def seg_postprocess(
-        data: Tuple[Tensor, Tensor, Tensor, Tensor],
-        shape: Union[Tuple, List]) \
-        -> Tuple[Tensor, Tensor, Tensor, List]:
-    assert len(data) == 4
-    bboxes, scores, labels, masks = data
-    idx = scores > 0
-    bboxes, scores, labels, masks = bboxes[idx], scores[idx], labels[
-        idx], masks[idx]
-    masks = crop_mask(masks, bboxes / 4.)
-    masks = F.interpolate(masks[None],
-                          shape,
-                          mode='bilinear',
-                          align_corners=False)[0]
-    masks = masks.gt_(0.5)[..., None]
-    cidx = (labels % len(MASK_COLORS)).cpu().numpy()
-    mask_color = torch.tensor(MASK_COLORS[cidx].reshape(-1, 1, 1,
-                                                        3)).to(bboxes) * ALPHA
-    out = [masks, masks @ mask_color]
-    return bboxes, scores, labels, out
-
-
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('--engine', type=str, help='Engine file')
@@ -213,15 +125,6 @@ def parse_args():
                         help='Profile TensorRT engine')
     args = parser.parse_args()
     return args
-
-
-def profile(args):
-    device = torch.device(args.device)
-    Engine = TRTModule(args.engine, device)
-    profiler = TRTProfilerV0()
-    Engine.set_profiler(profiler)
-    random_input = torch.randn(Engine.inp_info[0].shape, device=device)
-    _ = Engine(random_input)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Speed test code:

```py
        from tqdm import tqdm
        for _ in tqdm(range(10000)):
            data = Engine(tensor)
            bboxes, scores, labels, masks = seg_postprocess(data, bgr.shape[:2])
```

Test environment:

```
cuda_11.8.0_522.06_windows.exe
cudnn-windows-x86_64-8.6.0.163_cuda11-archive
TensorRT-8.5.3.1.Windows10.x86_64.cuda-11.8.cudnn8.6.zip

CPU: i9-12900K
MEM: 32GB DDR5 4800MHz
GPU: RTX 3080Ti
```

Before: 239fps

<img width="407" alt="image" src="https://user-images.githubusercontent.com/10473170/217749075-968dcf0b-0d13-411d-a3de-4536865c49ff.png">

After: 381fps

<img width="416" alt="image" src="https://user-images.githubusercontent.com/10473170/217749099-5b1ee251-a73a-4c3a-a6fb-9b54e6e3cf68.png">

