### PR TITLE
The Jetson Nano can run this code with a small change to the cmake options

### DIFF
--- a/csrc/jetson/detect/CMakeLists.txt
+++ b/csrc/jetson/detect/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 
-set(CMAKE_CUDA_ARCHITECTURES 60 61 62 70 72 75 86)
+set(CMAKE_CUDA_ARCHITECTURES 60 61 62 70 72 75)
 set(CMAKE_CUDA_COMPILER /usr/local/cuda/bin/nvcc)
 
 project(yolov8 LANGUAGES CXX CUDA)


### PR DESCRIPTION
(DON'T MERGE THIS - see below)
By removing compute_86, this code compiles and runs with the following library versions:

- Jetpack-4.7.2
- CUDA-10.2
- CUDNN-8.2.1
- TensorRT-8.2.1
- OpenCV-4.7.0 (you could probably use an earlier version)
- CMake-3.26.3 (you could probably use an earlier version)

You need gcc-8/g++-8 or better.  Onnxsim requires onnxoptimizer, which struggles to compile on the nano, recommend making sure everything else is closed before installing.  Use a lightdm or similar window manager if you need one to cut down on background memory usage and aren't going headless. 

Is there a better way to make the CMakelists only use compute_86 if the hardware isn't the nano?  Or add a nano option to make?  Actually deleting the compute_86 is probably detrimental to performance on other platforms. (AKA DON'T MERGE THIS)