### PR TITLE
Handle case when no bounding boxes are detected during segmentation

### DIFF
--- a/infer-seg.py
+++ b/infer-seg.py
@@ -42,6 +42,11 @@ def main(args: argparse.Namespace) -> None:
                                 device=device)
         bboxes, scores, labels, masks = seg_postprocess(
             data, bgr.shape[:2], args.conf_thres, args.iou_thres)
+        if bboxes is None:
+            # if no bounding box or others save original image
+            if not args.show:
+                cv2.imwrite(str(save_image), draw)
+            continue
         masks = masks[:, dh:H - dh, dw:W - dw, :]
         indices = (labels % len(MASK_COLORS)).long()
         mask_colors = torch.asarray(MASK_COLORS, device=device)[indices]

--- a/models/torch_utils.py
+++ b/models/torch_utils.py
@@ -18,6 +18,8 @@ def seg_postprocess(
     bboxes, scores, labels, maskconf = outputs.split([4, 1, 1, 32], 1)
     scores, labels = scores.squeeze(), labels.squeeze()
     idx = scores > conf_thres
+    if idx.sum() == 0:  # no bounding boxes or seg were created
+        return None, None, None, None
     bboxes, scores, labels, maskconf = \
         bboxes[idx], scores[idx], labels[idx], maskconf[idx]
     idx = batched_nms(bboxes, scores, labels, iou_thres)


### PR DESCRIPTION
Hi, i had a dataset for inference which may not contain anything to segmentate. While in inference mode, i got the error of "RuntimeError: Non-empty 4D data tensor expected but got a tensor with sizes [1, 0, 216, 216]" for those samples. So, it seemed like a good idea to add a handle for samples with no segmentation. Thank you, have a nice day.
## What does this PR do?

This pull request handles the case where no bounding boxes are detected by the segmentation post-processing function. Instead of causing the application to crash, it now checks for `None` return values from `seg_postprocess`. If it detects no bounding boxes, it saves the original image to save directory and moves to the next image for processing.

## How Has This Been Tested?

This change has been tested locally with various inputs including cases where no bounding boxes were detected. The function now handles these cases gracefully instead of crashing.
