### PR TITLE
Fix crash on non-quadratic segmentation masks

### DIFF
--- a/csrc/segment/normal/include/yolov8-seg.hpp
+++ b/csrc/segment/normal/include/yolov8-seg.hpp
@@ -326,7 +326,7 @@ void YOLOv8_seg::postprocess(
     }
     else {
         cv::Mat matmulRes = (masks * protos).t();
-        cv::Mat maskMat   = matmulRes.reshape(indices.size(), {seg_w, seg_h});
+        cv::Mat maskMat   = matmulRes.reshape(indices.size(), {seg_h, seg_w});
 
         std::vector<cv::Mat> maskChannels;
         cv::split(maskMat, maskChannels);

--- a/csrc/segment/simple/include/yolov8-seg.hpp
+++ b/csrc/segment/simple/include/yolov8-seg.hpp
@@ -300,7 +300,7 @@ void YOLOv8_seg::postprocess(
     }
     else {
         cv::Mat matmulRes = (masks * protos).t();
-        cv::Mat maskMat   = matmulRes.reshape(indices.size(), {seg_w, seg_h});
+        cv::Mat maskMat   = matmulRes.reshape(indices.size(), {seg_h, seg_w});
 
         std::vector<cv::Mat> maskChannels;
         cv::split(maskMat, maskChannels);


### PR DESCRIPTION
Hi,

I used a trained model with a segmentation mask of size 608x1280. The resulting masks have a shape of 152x320. The current version of the script crashes when cropping the `dest` to the `roi`.

```
v::Rect roi(scale_dw, scale_dh, seg_w - 2 * scale_dw, seg_h - 2 * scale_dh);

        for (int i = 0; i < indices.size(); i++) {
            cv::Mat dest, mask;
            cv::exp(-maskChannels[i], dest);
            dest = 1.0 / (1.0 + dest);
            dest = dest(roi);
            cv::resize(dest, mask, cv::Size((int)width, (int)height), cv::INTER_LINEAR);
            objs[i].boxMask = mask(objs[i].rect) > 0.5f;
```