### PR TITLE
feat(pose): support multi-class pose models

### DIFF
--- a/csrc/apps/pose.cpp
+++ b/csrc/apps/pose.cpp
@@ -10,7 +10,8 @@
 
 using namespace yolov8;
 
-// YOLOv8 pose: single class with 17 keypoints. Output [1, 4+1+51, anchors].
+// YOLOv8 pose: 17 keypoints with one or more classes. Output [1, 4+nc+51, anchors];
+// nc is usually 1 (person), so the score is the single class channel.
 class PoseEngine: public Engine {
 public:
     using Engine::Engine;
@@ -18,7 +19,9 @@ public:
     void postprocess(std::vector<Object>& objs) override
     {
         objs.clear();
-        const int   num_anchors = output_bindings_[0].dims.d[2];
+        const int   num_anchors  = output_bindings_[0].dims.d[2];
+        const int   num_channels = output_bindings_[0].dims.d[1];
+        const int   num_cls      = num_channels - 4 - 51;  // 51 = 17 keypoints x 3
         const float dw = pparam_.dw, dh = pparam_.dh;
         const float width = pparam_.width, height = pparam_.height, ratio = pparam_.ratio;
 
@@ -28,14 +31,21 @@ public:
         std::vector<int>                indices;
         std::vector<std::vector<float>> kpss;
 
-        cv::Mat output(output_bindings_[0].dims.d[1], num_anchors, CV_32F, host_ptrs_[0]);
+        cv::Mat output(num_channels, num_anchors, CV_32F, host_ptrs_[0]);
         output = output.t();
         for (int i = 0; i < num_anchors; ++i) {
-            auto        row_ptr   = output.row(i).ptr<float>();
-            auto        bbox_ptr  = row_ptr;
-            auto        score_ptr = row_ptr + 4;
-            auto        kps_ptr   = row_ptr + 5;
-            const float score     = *score_ptr;
+            auto  row_ptr   = output.row(i).ptr<float>();
+            auto  bbox_ptr  = row_ptr;
+            auto  score_ptr = row_ptr + 4;
+            auto  kps_ptr   = row_ptr + 4 + num_cls;
+            int   label     = 0;
+            float score     = score_ptr[0];
+            for (int c = 1; c < num_cls; ++c) {
+                if (score_ptr[c] > score) {
+                    score = score_ptr[c];
+                    label = c;
+                }
+            }
             if (score > config_.score_thres) {
                 const float x  = *bbox_ptr++ - dw;
                 const float y  = *bbox_ptr++ - dh;
@@ -56,7 +66,7 @@ public:
                 }
 
                 bboxes.emplace_back(cv::Rect_<float>(x0, y0, x1 - x0, y1 - y0));
-                labels.push_back(0);
+                labels.push_back(label);
                 scores.push_back(score);
                 kpss.push_back(std::move(kps));
             }
@@ -94,7 +104,12 @@ public:
         for (const auto& obj : objs) {
             cv::rectangle(res, obj.rect, {0, 0, 255}, 2);
             char text[256];
-            std::snprintf(text, sizeof(text), "person %.1f%%", obj.prob * 100);
+            if (obj.label == 0) {
+                std::snprintf(text, sizeof(text), "person %.1f%%", obj.prob * 100);
+            }
+            else {
+                std::snprintf(text, sizeof(text), "%d %.1f%%", obj.label, obj.prob * 100);
+            }
             int       base_line  = 0;
             cv::Size  label_size = cv::getTextSize(text, cv::FONT_HERSHEY_SIMPLEX, 0.4, 1, &base_line);
             const int x          = static_cast<int>(obj.rect.x);

--- a/models/tasks/pose.py
+++ b/models/tasks/pose.py
@@ -4,6 +4,12 @@ import numpy as np
 from config import COLORS, KPS_COLORS, LIMB_COLORS, SKELETON
 from models.utils import blob, letterbox
 
+# Single-class pose ("person") is the common case; a multi-class model reports
+# its other classes by index. `COLORS` is keyed by the COCO class order, so
+# index 0 is always "person" and the single-class path stays byte-identical.
+POSE_NAMES = ["person"]
+POSE_COLORS = list(COLORS.values())
+
 
 def process(engine, bgr, draw, ctx) -> bool:
     img, ratio, dwdh = letterbox(bgr, (ctx.width, ctx.height))
@@ -18,14 +24,14 @@ def process(engine, bgr, draw, ctx) -> bool:
 
         dwdh_arr = torch.asarray(dwdh * 2, dtype=torch.float32, device=ctx.device)
         data = engine(torch.asarray(tensor, device=ctx.device))
-        bboxes, scores, kpts = pose_postprocess(data, ctx.conf_thres, ctx.iou_thres)
+        bboxes, scores, kpts, labels = pose_postprocess(data, ctx.conf_thres, ctx.iou_thres)
         empty = bboxes.numel() == 0
     else:
         from models.utils import pose_postprocess
 
         dwdh_arr = np.array(dwdh * 2, dtype=np.float32)
         data = engine(np.ascontiguousarray(tensor))
-        bboxes, scores, kpts = pose_postprocess(data, ctx.conf_thres, ctx.iou_thres)
+        bboxes, scores, kpts, labels = pose_postprocess(data, ctx.conf_thres, ctx.iou_thres)
         empty = bboxes.size == 0
 
     if empty:
@@ -33,12 +39,14 @@ def process(engine, bgr, draw, ctx) -> bool:
     bboxes -= dwdh_arr
     bboxes /= ratio
 
-    for bbox, score, kpt in zip(bboxes, scores, kpts):
+    for bbox, score, kpt, label in zip(bboxes, scores, kpts, labels):
         bbox = (bbox.round().int() if ctx.torch else bbox.round().astype(np.int32)).tolist()
-        cv2.rectangle(draw, bbox[:2], bbox[2:], COLORS["person"], 2)
+        label = int(label)
+        name = POSE_NAMES[label] if label < len(POSE_NAMES) else str(label)
+        cv2.rectangle(draw, bbox[:2], bbox[2:], POSE_COLORS[label % len(POSE_COLORS)], 2)
         cv2.putText(
             draw,
-            f"person:{float(score):.3f}",
+            f"{name}:{float(score):.3f}",
             (bbox[0], bbox[1] - 2),
             cv2.FONT_HERSHEY_SIMPLEX,
             0.75,

--- a/models/torch_utils.py
+++ b/models/torch_utils.py
@@ -29,22 +29,28 @@ def seg_postprocess(
 
 def pose_postprocess(
     data: tuple | Tensor, conf_thres: float = 0.25, iou_thres: float = 0.65
-) -> tuple[Tensor, Tensor, Tensor]:
+) -> tuple[Tensor, Tensor, Tensor, Tensor]:
     if isinstance(data, tuple):
         assert len(data) == 1
         data = data[0]
     outputs = torch.transpose(data[0], 0, 1).contiguous()
-    bboxes, scores, kpts = outputs.split([4, 1, 51], 1)
-    scores, kpts = scores.squeeze(), kpts.squeeze()
+    num_cls = outputs.shape[-1] - 4 - 51  # 51 = 17 keypoints x 3; usually 1 (person)
+    bboxes, cls, kpts = outputs.split([4, num_cls, 51], 1)
+    scores, labels = cls.max(-1)
     idx = scores > conf_thres
-    if not idx.any():  # no bounding boxes or seg were created
-        return bboxes.new_zeros((0, 4)), scores.new_zeros((0,)), bboxes.new_zeros((0, 0, 0))
-    bboxes, scores, kpts = bboxes[idx], scores[idx], kpts[idx]
+    if not idx.any():  # no bounding boxes were created
+        return (
+            bboxes.new_zeros((0, 4)),
+            scores.new_zeros((0,)),
+            bboxes.new_zeros((0, 0, 0)),
+            labels.new_zeros((0,)),
+        )
+    bboxes, scores, kpts, labels = bboxes[idx], scores[idx], kpts[idx], labels[idx]
     xycenter, wh = bboxes.chunk(2, -1)
     bboxes = torch.cat([xycenter - 0.5 * wh, xycenter + 0.5 * wh], -1)
-    idx = nms(bboxes, scores, iou_thres)
-    bboxes, scores, kpts = bboxes[idx], scores[idx], kpts[idx]
-    return bboxes, scores, kpts.reshape(idx.shape[0], -1, 3)
+    keep = nms(bboxes, scores, iou_thres)
+    bboxes, scores, kpts, labels = bboxes[keep], scores[keep], kpts[keep], labels[keep]
+    return bboxes, scores, kpts.reshape(keep.shape[0], -1, 3), labels
 
 
 def det_postprocess(data: tuple[Tensor, Tensor, Tensor, Tensor]):

--- a/models/utils.py
+++ b/models/utils.py
@@ -168,33 +168,30 @@ def seg_postprocess(
 
 def pose_postprocess(
     data: tuple | ndarray, conf_thres: float = 0.25, iou_thres: float = 0.65
-) -> tuple[ndarray, ndarray, ndarray]:
+) -> tuple[ndarray, ndarray, ndarray, ndarray]:
     if isinstance(data, tuple):
         assert len(data) == 1
         data = data[0]
     outputs = np.transpose(data[0], (1, 0))
-    bboxes, scores, kpts = np.split(outputs, [4, 5], 1)
-    scores, kpts = scores.squeeze(), kpts.squeeze()
+    num_cls = outputs.shape[-1] - 4 - 51  # 51 = 17 keypoints x 3; usually 1 (person)
+    bboxes, cls, kpts = np.split(outputs, [4, 4 + num_cls], 1)
+    scores = cls.max(-1)
+    labels = cls.argmax(-1)
     idx = scores > conf_thres
-    if not idx.any():  # no bounding boxes or seg were created
+    if not idx.any():  # no bounding boxes were created
         return (
             np.empty((0, 4), dtype=np.float32),
             np.empty((0,), dtype=np.float32),
             np.empty((0, 0, 0), dtype=np.float32),
+            np.empty((0,), dtype=np.int32),
         )
-    bboxes, scores, kpts = bboxes[idx], scores[idx], kpts[idx]
-    xycenter, wh = np.split(
-        bboxes,
-        [
-            2,
-        ],
-        -1,
-    )
+    bboxes, scores, kpts, labels = bboxes[idx], scores[idx], kpts[idx], labels[idx]
+    xycenter, wh = np.split(bboxes, [2], -1)
     cvbboxes = np.concatenate([xycenter - 0.5 * wh, wh], -1)
-    idx = cv2.dnn.NMSBoxes(cvbboxes, scores, conf_thres, iou_thres)
-    cvbboxes, scores, kpts = cvbboxes[idx], scores[idx], kpts[idx]
+    nms = cv2.dnn.NMSBoxes(cvbboxes, scores, conf_thres, iou_thres)
+    cvbboxes, scores, kpts, labels = cvbboxes[nms], scores[nms], kpts[nms], labels[nms]
     cvbboxes[:, 2:] += cvbboxes[:, :2]
-    return cvbboxes, scores, kpts.reshape(idx.shape[0], -1, 3)
+    return cvbboxes, scores, kpts.reshape(nms.shape[0], -1, 3), labels
 
 
 def obb_postprocess(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from models.utils import NMSBoxes, blob, box_iou, det_postprocess, letterbox, sigmoid
+from models.utils import NMSBoxes, blob, box_iou, det_postprocess, letterbox, pose_postprocess, sigmoid
 
 
 def test_letterbox_shape_and_padding():
@@ -76,4 +76,30 @@ def test_det_postprocess_empty():
     num_dets = np.array([[0]], dtype=np.int32)
     z = np.zeros((1, 1, 4), dtype=np.float32)
     b, s, le = det_postprocess((num_dets, z, z[..., 0], z[..., 0].astype(np.int32)))
+    assert b.shape == (0, 4) and s.shape == (0,) and le.shape == (0,)
+
+
+def _pose_raw(cls_scores: list[float]) -> np.ndarray:
+    """One-anchor raw pose output [1, 4+nc+51, 1] with a valid box and given class scores."""
+    num_cls = len(cls_scores)
+    raw = np.zeros((1, 4 + num_cls + 51, 1), dtype=np.float32)
+    raw[0, :4, 0] = (320, 320, 100, 200)  # cx, cy, w, h
+    raw[0, 4 : 4 + num_cls, 0] = cls_scores
+    return raw
+
+
+def test_pose_postprocess_single_class():
+    b, s, k, le = pose_postprocess(_pose_raw([0.9]))
+    assert b.shape == (1, 4) and s.shape == (1,) and k.shape == (1, 17, 3)
+    assert abs(float(s[0]) - 0.9) < 1e-6 and le.tolist() == [0]
+
+
+def test_pose_postprocess_multi_class_argmax():
+    b, s, k, le = pose_postprocess(_pose_raw([0.3, 0.8, 0.5]))  # nc=3, argmax=1
+    assert le.tolist() == [1] and abs(float(s[0]) - 0.8) < 1e-6
+    assert k.shape == (1, 17, 3)
+
+
+def test_pose_postprocess_empty():
+    b, s, k, le = pose_postprocess(_pose_raw([0.1]))  # below conf_thres
     assert b.shape == (0, 4) and s.shape == (0,) and le.shape == (0,)


### PR DESCRIPTION
## 多类别 pose 支持

YOLOv8 pose 引擎的原始输出形状为 `[1, 4+nc+51, anchors]`，其中 `nc` 是类别数（标准 COCO pose 为 1，即 person）。原实现把 `nc` 写死成 1，多类别 pose 模型（见 #272 #205 #190 #294）的类别得分与标签因此丢失。

本 PR 让三处后处理（numpy / torch / C++）都改为 nc-aware：

- `nc = channels - 4 - 51`（51 = 17 个关键点 × 3）
- score 取类别通道的最大值，label 取 argmax
- pose 渲染按类别画名称/颜色

**向后兼容**：单类别（`nc=1`）路径逐字节一致 —— label 恒为 0 → 文本 `"person"`、框色取 COCO 调色板索引 0。

## 验证

- `data/bus.jpg` 上 Python（torch + cudart 后端）输出与重构前基线 **md5 完全一致**
- C++ `yolov8_pose` 检测结果不变（4 个 person，box / kps_sum 一致）
- 新增 `tests/test_utils.py` 合成张量用例：单类、多类 argmax、空结果（`pytest` 13 passed）

> 无公开多类别 pose 权重可端到端验证，故用合成张量锁定 nc 推断与 argmax 行为；单类别走真实引擎回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
