### PR TITLE
feat(infer): batched inference (batch > 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ python infer.py --task pose --backend pycuda --engine yolov8s-pose.engine --imgs
 | `--show` / `--out-dir`       | display in a window, or save to a directory         |
 | `--conf-thres` `--iou-thres` | thresholds (seg / pose / obb)                       |
 | `--device`                   | torch device, e.g. `cuda:0` (torch backend)         |
+| `--batch`                    | images per engine call (dynamic-batch engines)      |
+
+> **Batched inference.** Images are run in one engine call per batch and decoded
+> per image. A fixed-batch engine (e.g. exported with `batch=2`) is driven at its
+> own batch size; a dynamic-batch engine follows `--batch N`. With a single image
+> or a batch-1 engine the behaviour is unchanged.
 
 ### 4. Inference — C++
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -103,6 +103,9 @@ python infer.py --task pose --backend pycuda --engine yolov8s-pose.engine --imgs
 | `--show` / `--out-dir` | 弹窗显示，或保存到目录 |
 | `--conf-thres` `--iou-thres` | 阈值（seg / pose / obb） |
 | `--device` | torch 设备，如 `cuda:0`（torch 后端） |
+| `--batch` | 每次引擎调用的图片数（dynamic-batch 引擎） |
+
+> **批量推理**：同一批图片合并为一次引擎调用，再逐图解码。固定 batch 的引擎（如导出时 `batch=2`）按自身 batch 运行；dynamic-batch 引擎按 `--batch N` 运行。单张图片或 batch=1 引擎行为不变。
 
 ### 4. 推理 —— C++
 

--- a/csrc/apps/pose.cpp
+++ b/csrc/apps/pose.cpp
@@ -10,7 +10,8 @@
 
 using namespace yolov8;
 
-// YOLOv8 pose: single class with 17 keypoints. Output [1, 4+1+51, anchors].
+// YOLOv8 pose: 17 keypoints with one or more classes. Output [1, 4+nc+51, anchors];
+// nc is usually 1 (person), so the score is the single class channel.
 class PoseEngine: public Engine {
 public:
     using Engine::Engine;
@@ -18,7 +19,9 @@ public:
     void postprocess(std::vector<Object>& objs) override
     {
         objs.clear();
-        const int   num_anchors = output_bindings_[0].dims.d[2];
+        const int   num_anchors  = output_bindings_[0].dims.d[2];
+        const int   num_channels = output_bindings_[0].dims.d[1];
+        const int   num_cls      = num_channels - 4 - 51;  // 51 = 17 keypoints x 3
         const float dw = pparam_.dw, dh = pparam_.dh;
         const float width = pparam_.width, height = pparam_.height, ratio = pparam_.ratio;
 
@@ -28,14 +31,21 @@ public:
         std::vector<int>                indices;
         std::vector<std::vector<float>> kpss;
 
-        cv::Mat output(output_bindings_[0].dims.d[1], num_anchors, CV_32F, host_ptrs_[0]);
+        cv::Mat output(num_channels, num_anchors, CV_32F, host_ptrs_[0]);
         output = output.t();
         for (int i = 0; i < num_anchors; ++i) {
-            auto        row_ptr   = output.row(i).ptr<float>();
-            auto        bbox_ptr  = row_ptr;
-            auto        score_ptr = row_ptr + 4;
-            auto        kps_ptr   = row_ptr + 5;
-            const float score     = *score_ptr;
+            auto  row_ptr   = output.row(i).ptr<float>();
+            auto  bbox_ptr  = row_ptr;
+            auto  score_ptr = row_ptr + 4;
+            auto  kps_ptr   = row_ptr + 4 + num_cls;
+            int   label     = 0;
+            float score     = score_ptr[0];
+            for (int c = 1; c < num_cls; ++c) {
+                if (score_ptr[c] > score) {
+                    score = score_ptr[c];
+                    label = c;
+                }
+            }
             if (score > config_.score_thres) {
                 const float x  = *bbox_ptr++ - dw;
                 const float y  = *bbox_ptr++ - dh;
@@ -56,7 +66,7 @@ public:
                 }
 
                 bboxes.emplace_back(cv::Rect_<float>(x0, y0, x1 - x0, y1 - y0));
-                labels.push_back(0);
+                labels.push_back(label);
                 scores.push_back(score);
                 kpss.push_back(std::move(kps));
             }
@@ -94,7 +104,12 @@ public:
         for (const auto& obj : objs) {
             cv::rectangle(res, obj.rect, {0, 0, 255}, 2);
             char text[256];
-            std::snprintf(text, sizeof(text), "person %.1f%%", obj.prob * 100);
+            if (obj.label == 0) {
+                std::snprintf(text, sizeof(text), "person %.1f%%", obj.prob * 100);
+            }
+            else {
+                std::snprintf(text, sizeof(text), "%d %.1f%%", obj.label, obj.prob * 100);
+            }
             int       base_line  = 0;
             cv::Size  label_size = cv::getTextSize(text, cv::FONT_HERSHEY_SIMPLEX, 0.4, 1, &base_line);
             const int x          = static_cast<int>(obj.rect.x);

--- a/infer.py
+++ b/infer.py
@@ -12,8 +12,9 @@ import argparse
 from pathlib import Path
 
 import cv2
+import numpy as np
 
-from models.tasks import DESIRED_OUTPUTS, Context, get_task
+from models.tasks import DESIRED_OUTPUTS, Context, get_task, slice_batch
 from models.utils import path_to_list
 
 
@@ -44,32 +45,63 @@ def build_engine(backend: str, weight: str, device_str: str, task: str):
     raise SystemExit(f"unknown backend '{backend}' (choose torch / cudart / pycuda)")
 
 
+def run_engine(engine, batch_tensor, is_torch: bool, device):
+    if is_torch:
+        import torch
+
+        return engine(torch.asarray(batch_tensor, device=device))
+    return engine(np.ascontiguousarray(batch_tensor))
+
+
 def main(args: argparse.Namespace) -> None:
     task = get_task(args.task)
     engine, is_torch, device = build_engine(args.backend, args.engine, args.device, args.task)
     height, width = engine.inp_info[0].shape[-2:]
     ctx = Context(is_torch, device, args.conf_thres, args.iou_thres, height, width)
 
+    # The engine's batch dimension drives batching: a fixed batch (e.g. 2) is
+    # used as-is, a dynamic one (-1) follows --batch. Inputs are stacked into a
+    # single [N, 3, H, W] tensor for one engine call, then decoded per image.
+    engine_batch = engine.inp_info[0].shape[0]
+    dynamic = engine_batch is None or engine_batch < 1
+    batch = args.batch if dynamic else engine_batch
+    if not dynamic and args.batch != engine_batch:
+        print(f"engine has a fixed batch of {engine_batch}, ignoring --batch {args.batch}")
+
     images = path_to_list(args.imgs)
     save_dir = Path(args.out_dir)
     if not args.show:
         save_dir.mkdir(parents=True, exist_ok=True)
 
-    for image in images:
-        bgr = cv2.imread(str(image))
-        if bgr is None:
-            print(f"{image}: cannot read image, skipping")
+    for start in range(0, len(images), batch):
+        bgrs, names = [], []
+        for image in images[start : start + batch]:
+            bgr = cv2.imread(str(image))
+            if bgr is None:
+                print(f"{image}: cannot read image, skipping")
+                continue
+            bgrs.append(bgr)
+            names.append(image)
+        if not bgrs:
             continue
-        draw = bgr.copy()
-        found = task.process(engine, bgr, draw, ctx)
-        if not found:
-            print(f"{image}: no object!")
-            continue
-        if args.show:
-            cv2.imshow("result", draw)
-            cv2.waitKey(0)
-        else:
-            cv2.imwrite(str(save_dir / image.name), draw)
+
+        tensors, metas = zip(*(task.preprocess(bgr, ctx) for bgr in bgrs))
+        tensors = list(tensors)
+        n = len(tensors)
+        if not dynamic and n < batch:  # fixed-batch engine: pad the short final chunk
+            tensors += [tensors[-1]] * (batch - n)
+        data = run_engine(engine, np.concatenate(tensors, 0), is_torch, device)
+
+        for i in range(n):
+            draw = bgrs[i].copy()
+            if not task.postprocess(slice_batch(data, i), metas[i], draw, ctx):
+                print(f"{names[i]}: no object!")
+                continue
+            if args.show:
+                cv2.imshow("result", draw)
+                cv2.waitKey(0)
+            else:
+                cv2.imwrite(str(save_dir / names[i].name), draw)
 
 
 def parse_args() -> argparse.Namespace:
@@ -83,6 +115,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--conf-thres", type=float, default=0.25, help="Confidence threshold (seg/pose/obb)")
     parser.add_argument("--iou-thres", type=float, default=0.65, help="NMS IoU threshold (seg/pose/obb)")
     parser.add_argument("--device", type=str, default="cuda:0", help="Torch device (torch backend)")
+    parser.add_argument("--batch", type=int, default=1, help="Images per engine call (dynamic-batch engines only)")
     return parser.parse_args()
 
 

--- a/models/tasks/__init__.py
+++ b/models/tasks/__init__.py
@@ -1,13 +1,28 @@
 """Per-task inference handlers shared by the unified ``infer.py`` entry point.
 
-Each task module exposes ``process(engine, bgr, draw, ctx) -> bool`` which runs
-preprocess -> inference -> postprocess -> render for one image, drawing onto
-``draw`` in place and returning whether any object was found. The torch and
-numpy (cudart/pycuda) paths reuse ``models.torch_utils`` / ``models.utils``
-respectively, keeping the original numeric behaviour of both.
+Each task module exposes two functions:
+
+- ``preprocess(bgr, ctx) -> (tensor, meta)`` — letterbox/resize + blob for one
+  image; ``tensor`` is ``[1, 3, H, W]`` so a batch is just a concatenation.
+- ``postprocess(data, meta, draw, ctx) -> bool`` — decode one image's engine
+  output slice, draw onto ``draw`` in place, return whether anything was found.
+
+``infer.py`` runs the engine in between, so a batch of N images is one engine
+call on the stacked ``[N, 3, H, W]`` tensor followed by N per-image
+``postprocess`` calls (see ``slice_batch``). The torch and numpy (cudart/pycuda)
+paths reuse ``models.torch_utils`` / ``models.utils`` respectively, keeping the
+original numeric behaviour of both.
 """
 
 from dataclasses import dataclass
+
+
+def slice_batch(data, i: int):
+    """One image's slice of a batched engine output, keeping the leading dim
+    so the per-task postprocess functions stay batch-shaped (``data[0]`` etc.)."""
+    if isinstance(data, tuple):
+        return tuple(t[i : i + 1] for t in data)
+    return data[i : i + 1]
 
 
 @dataclass

--- a/models/tasks/cls.py
+++ b/models/tasks/cls.py
@@ -4,21 +4,18 @@ from config import CLASSES_CLS
 from models.utils import blob
 
 
-def process(engine, bgr, draw, ctx) -> bool:
+def preprocess(bgr, ctx):
     img = cv2.resize(bgr, (ctx.width, ctx.height))
     rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
     tensor = blob(rgb, return_seg=False)
+    return tensor, None
 
+
+def postprocess(data, meta, draw, ctx) -> bool:
     if ctx.torch:
-        import torch
-
-        data = engine(torch.asarray(tensor, device=ctx.device))
         score, cls_id = data[0].max(0)
         score, cls_id = float(score), int(cls_id)
     else:
-        import numpy as np
-
-        data = engine(np.ascontiguousarray(tensor))
         probs = data[0]
         cls_id = int(probs.argmax())
         score = float(probs[cls_id])

--- a/models/tasks/det.py
+++ b/models/tasks/det.py
@@ -5,25 +5,27 @@ from config import CLASSES_DET, COLORS
 from models.utils import blob, letterbox
 
 
-def process(engine, bgr, draw, ctx) -> bool:
+def preprocess(bgr, ctx):
     img, ratio, dwdh = letterbox(bgr, (ctx.width, ctx.height))
     rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
     tensor = blob(rgb, return_seg=False)
+    return tensor, (ratio, dwdh)
 
+
+def postprocess(data, meta, draw, ctx) -> bool:
+    ratio, dwdh = meta
     if ctx.torch:
         import torch
 
         from models.torch_utils import det_postprocess
 
         dwdh_arr = torch.asarray(dwdh * 2, dtype=torch.float32, device=ctx.device)
-        data = engine(torch.asarray(tensor, device=ctx.device))
         bboxes, scores, labels = det_postprocess(data)
         empty = bboxes.numel() == 0
     else:
         from models.utils import det_postprocess
 
         dwdh_arr = np.array(dwdh * 2, dtype=np.float32)
-        data = engine(np.ascontiguousarray(tensor))
         bboxes, scores, labels = det_postprocess(data)
         empty = bboxes.size == 0
 

--- a/models/tasks/obb.py
+++ b/models/tasks/obb.py
@@ -5,25 +5,27 @@ from config import CLASSES_OBB, COLORS_OBB
 from models.utils import blob, letterbox
 
 
-def process(engine, bgr, draw, ctx) -> bool:
+def preprocess(bgr, ctx):
     img, ratio, dwdh = letterbox(bgr, (ctx.width, ctx.height))
     rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
     tensor = blob(rgb, return_seg=False)
+    return tensor, (ratio, dwdh)
 
+
+def postprocess(data, meta, draw, ctx) -> bool:
+    ratio, dwdh = meta
     if ctx.torch:
         import torch
 
         from models.torch_utils import obb_postprocess
 
         dwdh_arr = torch.asarray(dwdh, dtype=torch.float32, device=ctx.device)
-        data = engine(torch.asarray(tensor, device=ctx.device))
         points, scores, labels = obb_postprocess(data, ctx.conf_thres, ctx.iou_thres)
         empty = points.numel() == 0
     else:
         from models.utils import obb_postprocess
 
         dwdh_arr = np.array(dwdh, dtype=np.float32)
-        data = engine(np.ascontiguousarray(tensor))
         points, scores, labels = obb_postprocess(data, ctx.conf_thres, ctx.iou_thres)
         empty = points.size == 0
 

--- a/models/tasks/pose.py
+++ b/models/tasks/pose.py
@@ -11,11 +11,16 @@ POSE_NAMES = ["person"]
 POSE_COLORS = list(COLORS.values())
 
 
-def process(engine, bgr, draw, ctx) -> bool:
+def preprocess(bgr, ctx):
     img, ratio, dwdh = letterbox(bgr, (ctx.width, ctx.height))
-    dw, dh = int(dwdh[0]), int(dwdh[1])
     rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
     tensor = blob(rgb, return_seg=False)
+    return tensor, (ratio, dwdh)
+
+
+def postprocess(data, meta, draw, ctx) -> bool:
+    ratio, dwdh = meta
+    dw, dh = int(dwdh[0]), int(dwdh[1])
 
     if ctx.torch:
         import torch
@@ -23,14 +28,12 @@ def process(engine, bgr, draw, ctx) -> bool:
         from models.torch_utils import pose_postprocess
 
         dwdh_arr = torch.asarray(dwdh * 2, dtype=torch.float32, device=ctx.device)
-        data = engine(torch.asarray(tensor, device=ctx.device))
         bboxes, scores, kpts, labels = pose_postprocess(data, ctx.conf_thres, ctx.iou_thres)
         empty = bboxes.numel() == 0
     else:
         from models.utils import pose_postprocess
 
         dwdh_arr = np.array(dwdh * 2, dtype=np.float32)
-        data = engine(np.ascontiguousarray(tensor))
         bboxes, scores, kpts, labels = pose_postprocess(data, ctx.conf_thres, ctx.iou_thres)
         empty = bboxes.size == 0
 

--- a/models/tasks/pose.py
+++ b/models/tasks/pose.py
@@ -4,6 +4,12 @@ import numpy as np
 from config import COLORS, KPS_COLORS, LIMB_COLORS, SKELETON
 from models.utils import blob, letterbox
 
+# Single-class pose ("person") is the common case; a multi-class model reports
+# its other classes by index. `COLORS` is keyed by the COCO class order, so
+# index 0 is always "person" and the single-class path stays byte-identical.
+POSE_NAMES = ["person"]
+POSE_COLORS = list(COLORS.values())
+
 
 def process(engine, bgr, draw, ctx) -> bool:
     img, ratio, dwdh = letterbox(bgr, (ctx.width, ctx.height))
@@ -18,14 +24,14 @@ def process(engine, bgr, draw, ctx) -> bool:
 
         dwdh_arr = torch.asarray(dwdh * 2, dtype=torch.float32, device=ctx.device)
         data = engine(torch.asarray(tensor, device=ctx.device))
-        bboxes, scores, kpts = pose_postprocess(data, ctx.conf_thres, ctx.iou_thres)
+        bboxes, scores, kpts, labels = pose_postprocess(data, ctx.conf_thres, ctx.iou_thres)
         empty = bboxes.numel() == 0
     else:
         from models.utils import pose_postprocess
 
         dwdh_arr = np.array(dwdh * 2, dtype=np.float32)
         data = engine(np.ascontiguousarray(tensor))
-        bboxes, scores, kpts = pose_postprocess(data, ctx.conf_thres, ctx.iou_thres)
+        bboxes, scores, kpts, labels = pose_postprocess(data, ctx.conf_thres, ctx.iou_thres)
         empty = bboxes.size == 0
 
     if empty:
@@ -33,12 +39,14 @@ def process(engine, bgr, draw, ctx) -> bool:
     bboxes -= dwdh_arr
     bboxes /= ratio
 
-    for bbox, score, kpt in zip(bboxes, scores, kpts):
+    for bbox, score, kpt, label in zip(bboxes, scores, kpts, labels):
         bbox = (bbox.round().int() if ctx.torch else bbox.round().astype(np.int32)).tolist()
-        cv2.rectangle(draw, bbox[:2], bbox[2:], COLORS["person"], 2)
+        label = int(label)
+        name = POSE_NAMES[label] if label < len(POSE_NAMES) else str(label)
+        cv2.rectangle(draw, bbox[:2], bbox[2:], POSE_COLORS[label % len(POSE_COLORS)], 2)
         cv2.putText(
             draw,
-            f"person:{float(score):.3f}",
+            f"{name}:{float(score):.3f}",
             (bbox[0], bbox[1] - 2),
             cv2.FONT_HERSHEY_SIMPLEX,
             0.75,

--- a/models/tasks/seg.py
+++ b/models/tasks/seg.py
@@ -5,13 +5,20 @@ from config import ALPHA, CLASSES_SEG, COLORS, MASK_COLORS
 from models.utils import blob, letterbox
 
 
-def process(engine, bgr, draw, ctx) -> bool:
+def preprocess(bgr, ctx):
     img, ratio, dwdh = letterbox(bgr, (ctx.width, ctx.height))
     dw, dh = int(dwdh[0]), int(dwdh[1])
     h, w = ctx.height, ctx.width
     rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
     tensor, seg_img = blob(rgb, return_seg=True)
     seg_img = seg_img[dh : h - dh, dw : w - dw, [2, 1, 0]]
+    return tensor, (ratio, dwdh, seg_img, img.shape[:2])
+
+
+def postprocess(data, meta, draw, ctx) -> bool:
+    ratio, dwdh, seg_img, img_shape = meta
+    dw, dh = int(dwdh[0]), int(dwdh[1])
+    h, w = ctx.height, ctx.width
 
     if ctx.torch:
         import torch
@@ -19,9 +26,8 @@ def process(engine, bgr, draw, ctx) -> bool:
         from models.torch_utils import seg_postprocess
 
         dwdh_arr = torch.asarray(dwdh * 2, dtype=torch.float32, device=ctx.device)
-        data = engine(torch.asarray(tensor, device=ctx.device))
         seg_img = torch.asarray(seg_img, device=ctx.device)
-        bboxes, scores, labels, masks = seg_postprocess(data, img.shape[:2], ctx.conf_thres, ctx.iou_thres)
+        bboxes, scores, labels, masks = seg_postprocess(data, img_shape, ctx.conf_thres, ctx.iou_thres)
         if bboxes.numel() == 0:
             return False
         masks = masks[:, dh : h - dh, dw : w - dw, :]
@@ -36,8 +42,7 @@ def process(engine, bgr, draw, ctx) -> bool:
         from models.utils import seg_postprocess
 
         dwdh_arr = np.array(dwdh * 2, dtype=np.float32)
-        data = engine(np.ascontiguousarray(tensor))
-        bboxes, scores, labels, masks = seg_postprocess(data, img.shape[:2], ctx.conf_thres, ctx.iou_thres)
+        bboxes, scores, labels, masks = seg_postprocess(data, img_shape, ctx.conf_thres, ctx.iou_thres)
         if bboxes.size == 0:
             return False
         masks = masks[:, dh : h - dh, dw : w - dw, :]

--- a/models/torch_utils.py
+++ b/models/torch_utils.py
@@ -29,22 +29,28 @@ def seg_postprocess(
 
 def pose_postprocess(
     data: tuple | Tensor, conf_thres: float = 0.25, iou_thres: float = 0.65
-) -> tuple[Tensor, Tensor, Tensor]:
+) -> tuple[Tensor, Tensor, Tensor, Tensor]:
     if isinstance(data, tuple):
         assert len(data) == 1
         data = data[0]
     outputs = torch.transpose(data[0], 0, 1).contiguous()
-    bboxes, scores, kpts = outputs.split([4, 1, 51], 1)
-    scores, kpts = scores.squeeze(), kpts.squeeze()
+    num_cls = outputs.shape[-1] - 4 - 51  # 51 = 17 keypoints x 3; usually 1 (person)
+    bboxes, cls, kpts = outputs.split([4, num_cls, 51], 1)
+    scores, labels = cls.max(-1)
     idx = scores > conf_thres
-    if not idx.any():  # no bounding boxes or seg were created
-        return bboxes.new_zeros((0, 4)), scores.new_zeros((0,)), bboxes.new_zeros((0, 0, 0))
-    bboxes, scores, kpts = bboxes[idx], scores[idx], kpts[idx]
+    if not idx.any():  # no bounding boxes were created
+        return (
+            bboxes.new_zeros((0, 4)),
+            scores.new_zeros((0,)),
+            bboxes.new_zeros((0, 0, 0)),
+            labels.new_zeros((0,)),
+        )
+    bboxes, scores, kpts, labels = bboxes[idx], scores[idx], kpts[idx], labels[idx]
     xycenter, wh = bboxes.chunk(2, -1)
     bboxes = torch.cat([xycenter - 0.5 * wh, xycenter + 0.5 * wh], -1)
-    idx = nms(bboxes, scores, iou_thres)
-    bboxes, scores, kpts = bboxes[idx], scores[idx], kpts[idx]
-    return bboxes, scores, kpts.reshape(idx.shape[0], -1, 3)
+    keep = nms(bboxes, scores, iou_thres)
+    bboxes, scores, kpts, labels = bboxes[keep], scores[keep], kpts[keep], labels[keep]
+    return bboxes, scores, kpts.reshape(keep.shape[0], -1, 3), labels
 
 
 def det_postprocess(data: tuple[Tensor, Tensor, Tensor, Tensor]):

--- a/models/utils.py
+++ b/models/utils.py
@@ -168,33 +168,30 @@ def seg_postprocess(
 
 def pose_postprocess(
     data: tuple | ndarray, conf_thres: float = 0.25, iou_thres: float = 0.65
-) -> tuple[ndarray, ndarray, ndarray]:
+) -> tuple[ndarray, ndarray, ndarray, ndarray]:
     if isinstance(data, tuple):
         assert len(data) == 1
         data = data[0]
     outputs = np.transpose(data[0], (1, 0))
-    bboxes, scores, kpts = np.split(outputs, [4, 5], 1)
-    scores, kpts = scores.squeeze(), kpts.squeeze()
+    num_cls = outputs.shape[-1] - 4 - 51  # 51 = 17 keypoints x 3; usually 1 (person)
+    bboxes, cls, kpts = np.split(outputs, [4, 4 + num_cls], 1)
+    scores = cls.max(-1)
+    labels = cls.argmax(-1)
     idx = scores > conf_thres
-    if not idx.any():  # no bounding boxes or seg were created
+    if not idx.any():  # no bounding boxes were created
         return (
             np.empty((0, 4), dtype=np.float32),
             np.empty((0,), dtype=np.float32),
             np.empty((0, 0, 0), dtype=np.float32),
+            np.empty((0,), dtype=np.int32),
         )
-    bboxes, scores, kpts = bboxes[idx], scores[idx], kpts[idx]
-    xycenter, wh = np.split(
-        bboxes,
-        [
-            2,
-        ],
-        -1,
-    )
+    bboxes, scores, kpts, labels = bboxes[idx], scores[idx], kpts[idx], labels[idx]
+    xycenter, wh = np.split(bboxes, [2], -1)
     cvbboxes = np.concatenate([xycenter - 0.5 * wh, wh], -1)
-    idx = cv2.dnn.NMSBoxes(cvbboxes, scores, conf_thres, iou_thres)
-    cvbboxes, scores, kpts = cvbboxes[idx], scores[idx], kpts[idx]
+    nms = cv2.dnn.NMSBoxes(cvbboxes, scores, conf_thres, iou_thres)
+    cvbboxes, scores, kpts, labels = cvbboxes[nms], scores[nms], kpts[nms], labels[nms]
     cvbboxes[:, 2:] += cvbboxes[:, :2]
-    return cvbboxes, scores, kpts.reshape(idx.shape[0], -1, 3)
+    return cvbboxes, scores, kpts.reshape(nms.shape[0], -1, 3), labels
 
 
 def obb_postprocess(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from models.utils import NMSBoxes, blob, box_iou, det_postprocess, letterbox, sigmoid
+from models.utils import NMSBoxes, blob, box_iou, det_postprocess, letterbox, pose_postprocess, sigmoid
 
 
 def test_letterbox_shape_and_padding():
@@ -76,4 +76,30 @@ def test_det_postprocess_empty():
     num_dets = np.array([[0]], dtype=np.int32)
     z = np.zeros((1, 1, 4), dtype=np.float32)
     b, s, le = det_postprocess((num_dets, z, z[..., 0], z[..., 0].astype(np.int32)))
+    assert b.shape == (0, 4) and s.shape == (0,) and le.shape == (0,)
+
+
+def _pose_raw(cls_scores: list[float]) -> np.ndarray:
+    """One-anchor raw pose output [1, 4+nc+51, 1] with a valid box and given class scores."""
+    num_cls = len(cls_scores)
+    raw = np.zeros((1, 4 + num_cls + 51, 1), dtype=np.float32)
+    raw[0, :4, 0] = (320, 320, 100, 200)  # cx, cy, w, h
+    raw[0, 4 : 4 + num_cls, 0] = cls_scores
+    return raw
+
+
+def test_pose_postprocess_single_class():
+    b, s, k, le = pose_postprocess(_pose_raw([0.9]))
+    assert b.shape == (1, 4) and s.shape == (1,) and k.shape == (1, 17, 3)
+    assert abs(float(s[0]) - 0.9) < 1e-6 and le.tolist() == [0]
+
+
+def test_pose_postprocess_multi_class_argmax():
+    b, s, k, le = pose_postprocess(_pose_raw([0.3, 0.8, 0.5]))  # nc=3, argmax=1
+    assert le.tolist() == [1] and abs(float(s[0]) - 0.8) < 1e-6
+    assert k.shape == (1, 17, 3)
+
+
+def test_pose_postprocess_empty():
+    b, s, k, le = pose_postprocess(_pose_raw([0.1]))  # below conf_thres
     assert b.shape == (0, 4) and s.shape == (0,) and le.shape == (0,)


### PR DESCRIPTION
## batch > 1 推理

`infer.py` 之前每次引擎调用只处理一张图，无法使用 batch-N 的引擎。本 PR 把每个任务 handler 拆成：

- `preprocess(bgr, ctx) -> (tensor, meta)` —— letterbox/resize + blob，`tensor` 为 `[1,3,H,W]`，一个 batch 即拼接。
- `postprocess(data, meta, draw, ctx) -> bool` —— 解码单张图的引擎输出切片并绘制。

`infer.py` 在两者之间运行引擎：一批 N 张图拼成单个 `[N,3,H,W]` 张量、一次引擎调用，再按 `slice_batch(data, i)`（保留前导维，故现有 postprocess 函数无需改动）逐图解码。

- **固定 batch 引擎**（如 `yolo export ... batch=2` 或 `export-det.py --input-shape 2 ...`）按自身 batch 运行，末尾不足的一批自动补齐。
- **dynamic-batch 引擎** 按 `--batch N` 运行。
- 单张图 / batch=1 引擎行为不变。

## 验证

- **batch=1 逐字节一致**：det / seg / pose / obb / cls 五任务（torch + cudart 后端）与重构前基线 md5 完全一致。
- **batch=2 正确性**：固定 batch=2 的 End2End 检测引擎（tuple 输出）与 pose 引擎（单张量输出）上，每张图的结果**与 batch 内位置无关**（`[bus, zidane]` 中的 bus 结果 == `[bus, bus]` 中的 bus 结果，md5 一致），证明切片正确、无跨图污染。
- batch=2 引擎 vs batch=1 引擎：检测数/标签一致，bbox 最大差 0.42px、score 最大差 0.0018（纯 fp16 kernel 差异）。
- `pytest` 13 passed。

> **依赖**：本 PR 栈在 #316（多类别 pose）之上 —— `pose.py` 的 preprocess/postprocess 拆分建立在其 4-tuple 返回上。建议先合并 #316；合并后本 PR 的 diff 将只剩 batch 相关改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
