### PR TITLE
feat(cpp): GPU preprocessing CUDA kernel (pinned async upload, --gpu-preprocess)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+tensorrtx/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,26 @@ endif()
 find_package(CUDAToolkit REQUIRED)  # provides CUDA::cudart (no CUDA language needed)
 find_package(OpenCV REQUIRED)
 find_package(TensorRT REQUIRED)
+
+# Optional CUDA toolchain for the GPU preprocessing kernel (opt-in --gpu-preprocess).
+# If nvcc is available we enable the CUDA language and compile preprocess.cu into the
+# core lib; otherwise the GPU path compiles to a stub that throws (CPU path unaffected).
+include(CheckLanguage)
+if(NOT CMAKE_CUDA_COMPILER AND EXISTS /usr/local/cuda/bin/nvcc)
+    set(CMAKE_CUDA_COMPILER /usr/local/cuda/bin/nvcc)
+endif()
+check_language(CUDA)
+if(CMAKE_CUDA_COMPILER)
+    # Set before enable_language(CUDA), which would otherwise default it to "52".
+    if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+        set(CMAKE_CUDA_ARCHITECTURES 75 86 89 90)  # Turing..Hopper; override with -D for others
+    endif()
+    enable_language(CUDA)
+    set(YOLOV8_GPU_PREPROCESS ON)
+    message(STATUS "GPU preprocessing: enabled (CUDA ${CMAKE_CUDA_COMPILER_VERSION}, arch ${CMAKE_CUDA_ARCHITECTURES})")
+else()
+    message(STATUS "GPU preprocessing: disabled (no CUDA compiler; --gpu-preprocess will be unavailable)")
+endif()
 print_var(TensorRT_VERSION_STRING)
 print_var(OpenCV_VERSION)
 

--- a/README.md
+++ b/README.md
@@ -118,8 +118,12 @@ python infer.py --task pose --backend pycuda --engine yolov8s-pose.engine --imgs
 cmake -S . -B build -DTensorRT_ROOT=/path/to/TensorRT
 cmake --build build -j
 export LD_LIBRARY_PATH=/path/to/TensorRT/lib:$LD_LIBRARY_PATH
-./build/bin/yolov8_detect yolov8s.engine data/bus.jpg --out-dir output   # --show / --profile / --labels
+./build/bin/yolov8_detect yolov8s.engine data/bus.jpg --out-dir output   # --show / --profile / --labels / --gpu-preprocess
 ```
+
+`--gpu-preprocess` runs letterbox + normalize as a CUDA kernel (raw uint8 image straight
+to the network input, no CPU/OpenCV step); it is opt-in and built only when a CUDA
+compiler is found. Results match the CPU path within tolerance (GPU bilinear ≠ `cv::resize`).
 
 Build details, multiple TensorRT/OpenCV versions, cuDNN for TensorRT 8 and the C++14 fallback are in **[docs/Build.md](docs/Build.md)**. Class names live in `data/labels/*.txt` (override with `--labels`).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -115,8 +115,10 @@ python infer.py --task pose --backend pycuda --engine yolov8s-pose.engine --imgs
 cmake -S . -B build -DTensorRT_ROOT=/path/to/TensorRT
 cmake --build build -j
 export LD_LIBRARY_PATH=/path/to/TensorRT/lib:$LD_LIBRARY_PATH
-./build/bin/yolov8_detect yolov8s.engine data/bus.jpg --out-dir output   # --show / --profile / --labels
+./build/bin/yolov8_detect yolov8s.engine data/bus.jpg --out-dir output   # --show / --profile / --labels / --gpu-preprocess
 ```
+
+`--gpu-preprocess` 用 CUDA kernel 做 letterbox + 归一化（原始 uint8 图直接变成网络输入，无 CPU/OpenCV 步骤）；opt-in，仅在找到 CUDA 编译器时构建。结果与 CPU 路径在容差内一致（GPU 双线性 ≠ `cv::resize`）。
 
 构建细节、多版本 TensorRT/OpenCV、TensorRT 8 的 cuDNN 依赖与 C++14 回退见 **[docs/Build.md](docs/Build.md)**。类别名在 `data/labels/*.txt`（用 `--labels` 覆盖）。
 

--- a/csrc/apps/cls.cpp
+++ b/csrc/apps/cls.cpp
@@ -59,6 +59,11 @@ protected:
         resize_blob(image, blob, config_.input_size, pparam_);
     }
 
+    bool letterbox_preproc() const override
+    {
+        return false;  // cls uses plain resize on the GPU path too
+    }
+
 private:
     std::vector<std::string> class_names_;
 };

--- a/csrc/core/CMakeLists.txt
+++ b/csrc/core/CMakeLists.txt
@@ -26,10 +26,19 @@ target_link_libraries(yolov8_core PUBLIC
     TensorRT::TensorRT
 )
 
+# GPU preprocessing kernel (opt-in). Compiled into the core lib only when the root
+# build found a CUDA compiler; otherwise the engine's --gpu-preprocess branch throws.
+if(YOLOV8_GPU_PREPROCESS)
+    target_sources(yolov8_core PRIVATE src/preprocess.cu)
+    target_compile_definitions(yolov8_core PUBLIC YOLOV8_GPU_PREPROCESS)
+    set_target_properties(yolov8_core PROPERTIES CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
+endif()
+
 # Require at least C++14 (the ghc::filesystem floor); the project default is C++17
 # (std::filesystem). Build with -DCMAKE_CXX_STANDARD=14 to exercise the ghc fallback.
 target_compile_features(yolov8_core PUBLIC cxx_std_14)
-target_compile_options(yolov8_core PRIVATE -Wall -Wextra)
+# Warning flags only for C++ TUs (nvcc rejects -Wall/-Wextra passed directly).
+target_compile_options(yolov8_core PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wall;-Wextra>)
 
 # TRT_10 / BATCHED_NMS are PUBLIC so task executables compile the same code paths.
 yolov8_apply_compile_defs(yolov8_core)

--- a/csrc/core/include/yolov8/config.hpp
+++ b/csrc/core/include/yolov8/config.hpp
@@ -15,10 +15,11 @@ struct InferConfig {
     int         seg_h        = 160;
     int         seg_w        = 160;
     std::string labels_path;  // empty -> built-in COCO names
-    bool        warmup  = true;
-    bool        show    = false;  // off by default (works headless); otherwise save
-    bool        profile = false;  // attach a per-layer IProfiler and print a report
-    std::string out_dir = "output";
+    bool        warmup         = true;
+    bool        show           = false;  // off by default (works headless); otherwise save
+    bool        profile        = false;  // attach a per-layer IProfiler and print a report
+    bool        gpu_preprocess = false;  // preprocess on GPU (CUDA kernel) instead of CPU/OpenCV
+    std::string out_dir        = "output";
 };
 
 struct CliArgs {

--- a/csrc/core/include/yolov8/engine.hpp
+++ b/csrc/core/include/yolov8/engine.hpp
@@ -38,8 +38,13 @@ public:
     void print_profile() const;  // prints the per-layer report if --profile was set
 
 protected:
-    // Preprocess one image into an NCHW blob. Default is letterbox; cls overrides it.
+    // Preprocess one image into an NCHW blob (CPU path). Default is letterbox; cls overrides it.
     virtual void preprocess(const cv::Mat& image, cv::Mat& blob);
+    // Whether the GPU preprocess path should letterbox (true) or plain-resize (false, cls).
+    virtual bool letterbox_preproc() const
+    {
+        return true;
+    }
 
     InferConfig          config_;
     std::vector<Binding> input_bindings_;
@@ -53,7 +58,9 @@ private:
     // Declared so destruction runs context -> engine -> runtime -> stream -> buffers.
     std::vector<DeviceBuffer>                 device_buffers_;
     std::vector<HostPinnedBuffer>             host_buffers_;
-    std::vector<void*>                        device_ptrs_;  // [inputs..., outputs...]
+    std::vector<void*>                        device_ptrs_;     // [inputs..., outputs...]
+    DeviceBuffer                              raw_input_;       // uint8 device buffer for --gpu-preprocess
+    HostPinnedBuffer                          raw_input_host_;  // pinned staging for a fast async H2D upload
     CudaStream                                stream_;
     TrtUniquePtr<nvinfer1::IRuntime>          runtime_;
     TrtUniquePtr<nvinfer1::ICudaEngine>       engine_;

--- a/csrc/core/include/yolov8/preprocess.hpp
+++ b/csrc/core/include/yolov8/preprocess.hpp
@@ -11,4 +11,14 @@ void letterbox(const cv::Mat& image, cv::Mat& out, const cv::Size& size, PrePara
 // Plain resize (no padding) into an NCHW float blob (RGB, /255). Used for classification.
 void resize_blob(const cv::Mat& image, cv::Mat& out, const cv::Size& size, PreParam& pparam);
 
+// GPU counterparts (defined in preprocess.cu, compiled only when CUDA is available).
+// `src` is a device-side uint8 HWC BGR image; `dst` is the device NCHW float input
+// buffer (RGB, /255) written directly. `stream` is a cudaStream_t passed as void* to
+// keep this header free of CUDA headers. Records scale/pad in `pparam` exactly like
+// the CPU versions above.
+void letterbox_cuda(
+    const unsigned char* src, int src_w, int src_h, float* dst, int dst_w, int dst_h, PreParam& pparam, void* stream);
+void resize_cuda(
+    const unsigned char* src, int src_w, int src_h, float* dst, int dst_w, int dst_h, PreParam& pparam, void* stream);
+
 }  // namespace yolov8

--- a/csrc/core/src/config.cpp
+++ b/csrc/core/src/config.cpp
@@ -26,6 +26,7 @@ namespace {
               << "  --out-dir <dir>   output directory (default \"" << d.out_dir << "\")\n"
               << "  --show            display results in a window instead of saving\n"
               << "  --profile         print a per-layer timing report\n"
+              << "  --gpu-preprocess  preprocess on the GPU (CUDA kernel) instead of CPU/OpenCV\n"
               << "  --no-warmup       skip warmup iterations\n"
               << "  -h, --help        show this help\n";
     std::exit(code);
@@ -99,6 +100,9 @@ CliArgs parse_args(int argc, char** argv, const InferConfig& defaults)
         }
         else if (a == "--profile") {
             args.config.profile = true;
+        }
+        else if (a == "--gpu-preprocess") {
+            args.config.gpu_preprocess = true;
         }
         else if (a == "--no-warmup") {
             args.config.warmup = false;

--- a/csrc/core/src/engine.cpp
+++ b/csrc/core/src/engine.cpp
@@ -4,6 +4,7 @@
 #include "yolov8/logger.hpp"
 #include "yolov8/preprocess.hpp"
 #include "yolov8/trt_compat.hpp"
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <vector>
@@ -117,12 +118,45 @@ void Engine::preprocess(const cv::Mat& image, cv::Mat& blob)
 
 void Engine::copy_from_mat(const cv::Mat& image)
 {
-    cv::Mat blob;
-    preprocess(image, blob);
-
     const auto& in = input_bindings_[0];
-    CUDA_CHECK(cudaMemcpyAsync(
-        device_ptrs_[0], blob.ptr<float>(), blob.total() * blob.elemSize(), cudaMemcpyHostToDevice, stream_.get()));
+
+    if (config_.gpu_preprocess) {
+#ifdef YOLOV8_GPU_PREPROCESS
+        // Upload the raw uint8 BGR image and let a CUDA kernel produce the NCHW float
+        // blob directly in the input buffer — no CPU letterbox/blob. Stage through a
+        // pinned host buffer so the H2D copy is truly async (pageable memory is not).
+        cv::Mat      src   = image.isContinuous() ? image : image.clone();
+        const size_t bytes = src.total() * src.elemSize();
+        if (raw_input_host_.bytes() < bytes) {
+            raw_input_host_ = HostPinnedBuffer(bytes);  // grow (move-assign frees the old buffer)
+        }
+        if (raw_input_.bytes() < bytes) {
+            raw_input_ = DeviceBuffer(bytes);
+        }
+        std::memcpy(raw_input_host_.data(), src.data, bytes);
+        CUDA_CHECK(
+            cudaMemcpyAsync(raw_input_.data(), raw_input_host_.data(), bytes, cudaMemcpyHostToDevice, stream_.get()));
+        auto*       dst = static_cast<float*>(device_ptrs_[0]);
+        const int   dw = config_.input_size.width, dh = config_.input_size.height;
+        const auto* raw = static_cast<const unsigned char*>(raw_input_.data());
+        if (letterbox_preproc()) {
+            letterbox_cuda(raw, src.cols, src.rows, dst, dw, dh, pparam_, stream_.get());
+        }
+        else {
+            resize_cuda(raw, src.cols, src.rows, dst, dw, dh, pparam_, stream_.get());
+        }
+        CUDA_CHECK(cudaGetLastError());
+#else
+        throw TrtException("--gpu-preprocess requires a CUDA-enabled build (no nvcc found at configure time)");
+#endif
+    }
+    else {
+        cv::Mat blob;
+        preprocess(image, blob);
+        CUDA_CHECK(cudaMemcpyAsync(
+            device_ptrs_[0], blob.ptr<float>(), blob.total() * blob.elemSize(), cudaMemcpyHostToDevice, stream_.get()));
+    }
+
     const nvinfer1::Dims4 shape{1, 3, config_.input_size.height, config_.input_size.width};
     compat::set_input_shape(context_.get(), 0, in.name, shape);
     compat::set_tensor_address(context_.get(), in.name, device_ptrs_[0]);

--- a/csrc/core/src/preprocess.cu
+++ b/csrc/core/src/preprocess.cu
@@ -1,0 +1,159 @@
+// GPU preprocessing: turn a raw uint8 HWC BGR image straight into the NCHW float
+// blob the network expects (RGB, /255), with optional letterbox padding. This is
+// the opt-in counterpart to the CPU path in preprocess.cpp; the host-side scalar
+// math (ratio/dw/dh) is kept identical so pparam_ — and thus postprocess box
+// rescaling — is unchanged. Bilinear sampling is not bit-identical to cv::resize,
+// so results match within tolerance, not byte-for-byte.
+
+#include "yolov8/preprocess.hpp"
+#include <cmath>
+#include <cuda_runtime.h>
+
+namespace yolov8 {
+
+namespace {
+
+// One thread per destination pixel. Outside the resized ROI we write the 114 pad
+// value; inside we bilinearly sample the source (cv::resize INTER_LINEAR mapping).
+__global__ void blob_kernel(const unsigned char* src,
+                            int                  src_w,
+                            int                  src_h,
+                            float*               dst,
+                            int                  dst_w,
+                            int                  dst_h,
+                            int                  roi_x,
+                            int                  roi_y,
+                            int                  roi_w,
+                            int                  roi_h,
+                            float                scale_x,
+                            float                scale_y)
+{
+    const int dx = blockIdx.x * blockDim.x + threadIdx.x;
+    const int dy = blockIdx.y * blockDim.y + threadIdx.y;
+    if (dx >= dst_w || dy >= dst_h) {
+        return;
+    }
+
+    const int plane = dst_w * dst_h;
+    const int idx   = dy * dst_w + dx;
+    const int rx    = dx - roi_x;
+    const int ry    = dy - roi_y;
+
+    if (rx < 0 || rx >= roi_w || ry < 0 || ry >= roi_h) {
+        const float pad      = 114.0f / 255.0f;
+        dst[0 * plane + idx] = pad;
+        dst[1 * plane + idx] = pad;
+        dst[2 * plane + idx] = pad;
+        return;
+    }
+
+    float sx = (rx + 0.5f) * scale_x - 0.5f;
+    float sy = (ry + 0.5f) * scale_y - 0.5f;
+    sx       = sx < 0.0f ? 0.0f : (sx > src_w - 1 ? src_w - 1 : sx);
+    sy       = sy < 0.0f ? 0.0f : (sy > src_h - 1 ? src_h - 1 : sy);
+
+    const int   x0  = static_cast<int>(sx);
+    const int   y0  = static_cast<int>(sy);
+    const int   x1  = x0 + 1 < src_w ? x0 + 1 : x0;
+    const int   y1  = y0 + 1 < src_h ? y0 + 1 : y0;
+    const float ax  = sx - x0;
+    const float ay  = sy - y0;
+    const float w00 = (1.0f - ax) * (1.0f - ay);
+    const float w01 = ax * (1.0f - ay);
+    const float w10 = (1.0f - ax) * ay;
+    const float w11 = ax * ay;
+
+    const unsigned char* p00 = src + (y0 * src_w + x0) * 3;
+    const unsigned char* p01 = src + (y0 * src_w + x1) * 3;
+    const unsigned char* p10 = src + (y1 * src_w + x0) * 3;
+    const unsigned char* p11 = src + (y1 * src_w + x1) * 3;
+
+    // Source is BGR (channel c: 0=B,1=G,2=R); output plane order is RGB, so
+    // channel c lands in plane (2 - c) — matching to_blob() in preprocess.cpp.
+#pragma unroll
+    for (int c = 0; c < 3; ++c) {
+        const float v              = w00 * p00[c] + w01 * p01[c] + w10 * p10[c] + w11 * p11[c];
+        dst[(2 - c) * plane + idx] = v / 255.0f;
+    }
+}
+
+void launch(const unsigned char* src,
+            int                  src_w,
+            int                  src_h,
+            float*               dst,
+            int                  dst_w,
+            int                  dst_h,
+            int                  roi_x,
+            int                  roi_y,
+            int                  roi_w,
+            int                  roi_h,
+            float                scale_x,
+            float                scale_y,
+            cudaStream_t         stream)
+{
+    const dim3 block(16, 16);
+    const dim3 grid((dst_w + block.x - 1) / block.x, (dst_h + block.y - 1) / block.y);
+    blob_kernel<<<grid, block, 0, stream>>>(
+        src, src_w, src_h, dst, dst_w, dst_h, roi_x, roi_y, roi_w, roi_h, scale_x, scale_y);
+}
+
+}  // namespace
+
+void letterbox_cuda(
+    const unsigned char* src, int src_w, int src_h, float* dst, int dst_w, int dst_h, PreParam& pparam, void* stream)
+{
+    // Identical scalar math to preprocess.cpp::letterbox so pparam stays the same.
+    const float r    = std::min(static_cast<float>(dst_h) / src_h, static_cast<float>(dst_w) / src_w);
+    const int   padw = static_cast<int>(std::round(src_w * r));
+    const int   padh = static_cast<int>(std::round(src_h * r));
+    const float dw   = (dst_w - padw) / 2.0f;
+    const float dh   = (dst_h - padh) / 2.0f;
+    const int   left = static_cast<int>(std::round(dw - 0.1f));
+    const int   top  = static_cast<int>(std::round(dh - 0.1f));
+
+    launch(src,
+           src_w,
+           src_h,
+           dst,
+           dst_w,
+           dst_h,
+           left,
+           top,
+           padw,
+           padh,
+           static_cast<float>(src_w) / padw,
+           static_cast<float>(src_h) / padh,
+           static_cast<cudaStream_t>(stream));
+
+    pparam.ratio  = 1.0f / r;
+    pparam.dw     = dw;
+    pparam.dh     = dh;
+    pparam.height = src_h;
+    pparam.width  = src_w;
+}
+
+void resize_cuda(
+    const unsigned char* src, int src_w, int src_h, float* dst, int dst_w, int dst_h, PreParam& pparam, void* stream)
+{
+    launch(src,
+           src_w,
+           src_h,
+           dst,
+           dst_w,
+           dst_h,
+           0,
+           0,
+           dst_w,
+           dst_h,
+           static_cast<float>(src_w) / dst_w,
+           static_cast<float>(src_h) / dst_h,
+           static_cast<cudaStream_t>(stream));
+
+    pparam.ratio  = 1.0f;
+    pparam.dw     = 0.0f;
+    pparam.dh     = 0.0f;
+    pparam.height = src_h;
+    pparam.width  = src_w;
+}
+
+}  // namespace yolov8

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -77,6 +77,18 @@ cmake -S . -B build -DTensorRT_ROOT=/path/to/TensorRT -DCMAKE_CXX_STANDARD=14
 cmake --build build -j
 ```
 
+## GPU preprocessing (opt-in)
+
+By default preprocessing (letterbox + BGR→RGB + normalize) runs on the CPU via OpenCV.
+Passing `--gpu-preprocess` at runtime instead uploads the raw uint8 image and does the
+whole transform in a CUDA kernel, writing the network input directly — no CPU/OpenCV step.
+
+It is compiled only when CMake finds a CUDA compiler (the configure log prints
+`GPU preprocessing: enabled`); otherwise `--gpu-preprocess` throws and the CPU path is
+unaffected. Set GPU architectures with `-DCMAKE_CUDA_ARCHITECTURES=86` (default
+`75;86;89;90`). The kernel's bilinear resize is not bit-identical to `cv::resize`, so
+detections match the CPU path within tolerance, not byte-for-byte.
+
 ## Tests
 
 ```shell


### PR DESCRIPTION
## GPU 前处理 CUDA kernel（opt-in，自包含）

C++ 前处理（letterbox + BGR→RGB + /255 + HWC→CHW）原本全在 CPU（OpenCV）做再 H2D。本 PR 增加可选 GPU 路径：原始 uint8 图经 **pinned host 暂存**一次 H2D，由单个 CUDA kernel（`preprocess.cu`）直接写出 NCHW float 输入 —— 无 CPU 前处理。

- `preprocess.cu`：双线性 letterbox/resize + RGB + 归一化；host 标量算法与 `preprocess.cpp` 逐字一致（`pparam_` 不变）。
- pinned 暂存（`HostPinnedBuffer raw_input_host_`）让 H2D 真正异步（~1.17×、可与计算重叠）。
- `--gpu-preprocess` 开关，**默认关闭**；CMake 仅在找到 nvcc 时启用 CUDA。

**验证**：`data/bus.jpg` det CPU vs GPU 同目标/标签、score 差<1e-2；TRT 8.6/10.16/11.0 编译运行。结果非逐字节（GPU 双线性≠cv::resize），属预期。

> 栈式系列第 1 个（#318→#319→#320→#321→#322，按序合并）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
