### PR TITLE
feat: YoloObbPostprocess plugin (GPU rotated NMS via ProbIoU)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+tensorrtx/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,26 @@ endif()
 find_package(CUDAToolkit REQUIRED)  # provides CUDA::cudart (no CUDA language needed)
 find_package(OpenCV REQUIRED)
 find_package(TensorRT REQUIRED)
+
+# Optional CUDA toolchain for the GPU preprocessing kernel (opt-in --gpu-preprocess).
+# If nvcc is available we enable the CUDA language and compile preprocess.cu into the
+# core lib; otherwise the GPU path compiles to a stub that throws (CPU path unaffected).
+include(CheckLanguage)
+if(NOT CMAKE_CUDA_COMPILER AND EXISTS /usr/local/cuda/bin/nvcc)
+    set(CMAKE_CUDA_COMPILER /usr/local/cuda/bin/nvcc)
+endif()
+check_language(CUDA)
+if(CMAKE_CUDA_COMPILER)
+    # Set before enable_language(CUDA), which would otherwise default it to "52".
+    if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+        set(CMAKE_CUDA_ARCHITECTURES 75 86 89 90)  # Turing..Hopper; override with -D for others
+    endif()
+    enable_language(CUDA)
+    set(YOLOV8_GPU_PREPROCESS ON)
+    message(STATUS "GPU preprocessing: enabled (CUDA ${CMAKE_CUDA_COMPILER_VERSION}, arch ${CMAKE_CUDA_ARCHITECTURES})")
+else()
+    message(STATUS "GPU preprocessing: disabled (no CUDA compiler; --gpu-preprocess will be unavailable)")
+endif()
 print_var(TensorRT_VERSION_STRING)
 print_var(OpenCV_VERSION)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,15 @@ endif()
 # them natively on the device (or cross-compile) with -DTensorRT_ROOT pointing at
 # the aarch64 TensorRT. No separate Jetson sources are needed.
 
+# Custom TensorRT postprocess plugins (libyolov8_plugins.so) — opt-in, needs CUDA.
+option(BUILD_PLUGINS "Build the custom TensorRT postprocess plugins" OFF)
+if(BUILD_PLUGINS)
+    if(NOT YOLOV8_GPU_PREPROCESS)
+        message(FATAL_ERROR "BUILD_PLUGINS requires a CUDA compiler (none found at configure time)")
+    endif()
+    add_subdirectory(csrc/plugins)
+endif()
+
 # DeepStream parser plugin — needs the DeepStream SDK, so it is off by default.
 option(BUILD_DEEPSTREAM "Build the DeepStream parser plugin" OFF)
 if(BUILD_DEEPSTREAM)

--- a/README.md
+++ b/README.md
@@ -118,8 +118,12 @@ python infer.py --task pose --backend pycuda --engine yolov8s-pose.engine --imgs
 cmake -S . -B build -DTensorRT_ROOT=/path/to/TensorRT
 cmake --build build -j
 export LD_LIBRARY_PATH=/path/to/TensorRT/lib:$LD_LIBRARY_PATH
-./build/bin/yolov8_detect yolov8s.engine data/bus.jpg --out-dir output   # --show / --profile / --labels
+./build/bin/yolov8_detect yolov8s.engine data/bus.jpg --out-dir output   # --show / --profile / --labels / --gpu-preprocess
 ```
+
+`--gpu-preprocess` runs letterbox + normalize as a CUDA kernel (raw uint8 image straight
+to the network input, no CPU/OpenCV step); it is opt-in and built only when a CUDA
+compiler is found. Results match the CPU path within tolerance (GPU bilinear ≠ `cv::resize`).
 
 Build details, multiple TensorRT/OpenCV versions, cuDNN for TensorRT 8 and the C++14 fallback are in **[docs/Build.md](docs/Build.md)**. Class names live in `data/labels/*.txt` (override with `--labels`).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -115,8 +115,10 @@ python infer.py --task pose --backend pycuda --engine yolov8s-pose.engine --imgs
 cmake -S . -B build -DTensorRT_ROOT=/path/to/TensorRT
 cmake --build build -j
 export LD_LIBRARY_PATH=/path/to/TensorRT/lib:$LD_LIBRARY_PATH
-./build/bin/yolov8_detect yolov8s.engine data/bus.jpg --out-dir output   # --show / --profile / --labels
+./build/bin/yolov8_detect yolov8s.engine data/bus.jpg --out-dir output   # --show / --profile / --labels / --gpu-preprocess
 ```
+
+`--gpu-preprocess` 用 CUDA kernel 做 letterbox + 归一化（原始 uint8 图直接变成网络输入，无 CPU/OpenCV 步骤）；opt-in，仅在找到 CUDA 编译器时构建。结果与 CPU 路径在容差内一致（GPU 双线性 ≠ `cv::resize`）。
 
 构建细节、多版本 TensorRT/OpenCV、TensorRT 8 的 cuDNN 依赖与 C++14 回退见 **[docs/Build.md](docs/Build.md)**。类别名在 `data/labels/*.txt`（用 `--labels` 覆盖）。
 

--- a/csrc/apps/cls.cpp
+++ b/csrc/apps/cls.cpp
@@ -59,6 +59,11 @@ protected:
         resize_blob(image, blob, config_.input_size, pparam_);
     }
 
+    bool letterbox_preproc() const override
+    {
+        return false;  // cls uses plain resize on the GPU path too
+    }
+
 private:
     std::vector<std::string> class_names_;
 };

--- a/csrc/apps/detect.cpp
+++ b/csrc/apps/detect.cpp
@@ -11,7 +11,10 @@
 
 using namespace yolov8;
 
-// YOLOv8 detection: a single output [1, 4+num_classes, num_anchors].
+// YOLOv8 detection. Auto-detects the engine kind from its outputs: a single
+// [1, 4+num_classes, num_anchors] tensor → raw decode + cv::dnn NMS; four tensors
+// (num_dets, bboxes, scores, labels) → NMS already baked in (EfficientNMS_TRT or the
+// YoloDetPostprocess plugin), so we only rescale. One binary handles all three.
 class DetectEngine: public Engine {
 public:
     DetectEngine(const std::string& engine_path, const InferConfig& config): Engine(engine_path, config)
@@ -22,6 +25,48 @@ public:
     void postprocess(std::vector<Object>& objs) override
     {
         objs.clear();
+        if (output_bindings_.size() >= 4) {
+            postprocess_end2end(objs);
+        }
+        else {
+            postprocess_raw(objs);
+        }
+    }
+
+    void draw(const cv::Mat& image, cv::Mat& res, const std::vector<Object>& objs) const override
+    {
+        draw_detections(image, res, objs, class_names_);
+    }
+
+private:
+    // NMS baked into the engine: outputs are num_dets, bboxes, scores, labels.
+    void postprocess_end2end(std::vector<Object>& objs)
+    {
+        const int*   num_dets = static_cast<const int*>(host_ptrs_[0]);
+        const float* boxes    = static_cast<const float*>(host_ptrs_[1]);
+        const float* scores   = static_cast<const float*>(host_ptrs_[2]);
+        const int*   labels   = static_cast<const int*>(host_ptrs_[3]);
+        const float  dw = pparam_.dw, dh = pparam_.dh;
+        const float  width = pparam_.width, height = pparam_.height, ratio = pparam_.ratio;
+
+        for (int i = 0; i < num_dets[0]; ++i) {
+            const float* ptr = boxes + i * 4;
+            const float  x0  = clamp((ptr[0] - dw) * ratio, 0.f, width);
+            const float  y0  = clamp((ptr[1] - dh) * ratio, 0.f, height);
+            const float  x1  = clamp((ptr[2] - dw) * ratio, 0.f, width);
+            const float  y1  = clamp((ptr[3] - dh) * ratio, 0.f, height);
+
+            Object obj;
+            obj.rect  = cv::Rect_<float>(x0, y0, x1 - x0, y1 - y0);
+            obj.prob  = scores[i];
+            obj.label = labels[i];
+            objs.push_back(obj);
+        }
+    }
+
+    // Raw head output [1, 4+num_classes, num_anchors]: decode + NMS on the host.
+    void postprocess_raw(std::vector<Object>& objs)
+    {
         const int   num_channels = output_bindings_[0].dims.d[1];
         const int   num_anchors  = output_bindings_[0].dims.d[2];
         const int   num_labels   = num_channels - 4;
@@ -78,12 +123,6 @@ public:
         }
     }
 
-    void draw(const cv::Mat& image, cv::Mat& res, const std::vector<Object>& objs) const override
-    {
-        draw_detections(image, res, objs, class_names_);
-    }
-
-private:
     std::vector<std::string> class_names_;
 };
 

--- a/csrc/apps/obb.cpp
+++ b/csrc/apps/obb.cpp
@@ -23,6 +23,56 @@ public:
     void postprocess(std::vector<Object>& objs) override
     {
         objs.clear();
+        if (binding_index("num_dets") >= 0) {
+            postprocess_plugin(objs);
+        }
+        else {
+            postprocess_raw(objs);
+        }
+    }
+
+private:
+    int binding_index(const std::string& name) const
+    {
+        for (size_t i = 0; i < output_bindings_.size(); ++i) {
+            if (output_bindings_[i].name == name) {
+                return static_cast<int>(i);
+            }
+        }
+        return -1;
+    }
+
+    // YoloObbPostprocess plugin: rotated NMS in-engine; only rescale + build rrect.
+    void postprocess_plugin(std::vector<Object>& objs)
+    {
+        const int*   num_dets = static_cast<const int*>(host_ptrs_[binding_index("num_dets")]);
+        const float* boxes    = static_cast<const float*>(host_ptrs_[binding_index("bboxes")]);
+        const float* scores   = static_cast<const float*>(host_ptrs_[binding_index("scores")]);
+        const int*   labels   = static_cast<const int*>(host_ptrs_[binding_index("labels")]);
+        const float* angles   = static_cast<const float*>(host_ptrs_[binding_index("angles")]);
+        const float  dw = pparam_.dw, dh = pparam_.dh;
+        const float  width = pparam_.width, height = pparam_.height, ratio = pparam_.ratio;
+
+        for (int i = 0; i < num_dets[0]; ++i) {
+            const float* bp = boxes + i * 4;
+            const float  x  = clamp((bp[0] - dw) * ratio, 0.f, width);
+            const float  y  = clamp((bp[1] - dh) * ratio, 0.f, height);
+            const float  w  = clamp(bp[2] * ratio, 0.f, width);
+            const float  h  = clamp(bp[3] * ratio, 0.f, height);
+            if (w < 1.f || h < 1.f) {
+                continue;
+            }
+            Object obj;
+            obj.rrect     = cv::RotatedRect(cv::Point2f(x, y), cv::Size2f(w, h), angles[i] / CV_PI * 180.f);
+            obj.has_rrect = true;
+            obj.prob      = scores[i];
+            obj.label     = labels[i];
+            objs.push_back(obj);
+        }
+    }
+
+    void postprocess_raw(std::vector<Object>& objs)
+    {
         const int   num_channels = output_bindings_[0].dims.d[1];
         const int   num_anchors  = output_bindings_[0].dims.d[2];
         const int   num_labels   = num_channels - 5;  // 4 box coords + nc + 1 angle
@@ -81,6 +131,7 @@ public:
         }
     }
 
+public:
     void draw(const cv::Mat& image, cv::Mat& res, const std::vector<Object>& objs) const override
     {
         const Palette& colors = palette();

--- a/csrc/apps/pose.cpp
+++ b/csrc/apps/pose.cpp
@@ -19,6 +19,59 @@ public:
     void postprocess(std::vector<Object>& objs) override
     {
         objs.clear();
+        if (binding_index("num_dets") >= 0) {
+            postprocess_plugin(objs);
+        }
+        else {
+            postprocess_raw(objs);
+        }
+    }
+
+private:
+    int binding_index(const std::string& name) const
+    {
+        for (size_t i = 0; i < output_bindings_.size(); ++i) {
+            if (output_bindings_[i].name == name) {
+                return static_cast<int>(i);
+            }
+        }
+        return -1;
+    }
+
+    // YoloPosePostprocess plugin: NMS + kpt gather in-engine; only rescale here.
+    void postprocess_plugin(std::vector<Object>& objs)
+    {
+        const int*   num_dets = static_cast<const int*>(host_ptrs_[binding_index("num_dets")]);
+        const float* boxes    = static_cast<const float*>(host_ptrs_[binding_index("bboxes")]);
+        const float* scores   = static_cast<const float*>(host_ptrs_[binding_index("scores")]);
+        const int*   labels   = static_cast<const int*>(host_ptrs_[binding_index("labels")]);
+        const float* kpts     = static_cast<const float*>(host_ptrs_[binding_index("kpts")]);
+        const float  dw = pparam_.dw, dh = pparam_.dh;
+        const float  width = pparam_.width, height = pparam_.height, ratio = pparam_.ratio;
+
+        for (int i = 0; i < num_dets[0]; ++i) {
+            const float* bp = boxes + i * 4;
+            // Clamp all four corners, then derive w/h (matches detect_e2e / segment).
+            const float x0 = clamp((bp[0] - dw) * ratio, 0.f, width);
+            const float y0 = clamp((bp[1] - dh) * ratio, 0.f, height);
+            const float x1 = clamp((bp[2] - dw) * ratio, 0.f, width);
+            const float y1 = clamp((bp[3] - dh) * ratio, 0.f, height);
+            Object      obj;
+            obj.rect        = cv::Rect_<float>(x0, y0, x1 - x0, y1 - y0);
+            obj.prob        = scores[i];
+            obj.label       = labels[i];
+            const float* kp = kpts + i * 51;
+            for (int k = 0; k < 17; ++k) {
+                obj.kps.push_back(clamp((kp[3 * k] - dw) * ratio, 0.f, width));
+                obj.kps.push_back(clamp((kp[3 * k + 1] - dh) * ratio, 0.f, height));
+                obj.kps.push_back(kp[3 * k + 2]);
+            }
+            objs.push_back(obj);
+        }
+    }
+
+    void postprocess_raw(std::vector<Object>& objs)
+    {
         const int   num_anchors  = output_bindings_[0].dims.d[2];
         const int   num_channels = output_bindings_[0].dims.d[1];
         const int   num_cls      = num_channels - 4 - 51;  // 51 = 17 keypoints x 3
@@ -93,6 +146,7 @@ public:
         }
     }
 
+public:
     void draw(const cv::Mat& image, cv::Mat& res, const std::vector<Object>& objs) const override
     {
         const Palette& kps_colors  = pose::kps_colors();

--- a/csrc/apps/segment.cpp
+++ b/csrc/apps/segment.cpp
@@ -11,8 +11,10 @@
 
 using namespace yolov8;
 
-// YOLOv8 instance segmentation. Two outputs: detections [1, 4+nc+seg_channels, anchors]
-// and mask prototypes [1, seg_channels, seg_h, seg_w]. Binding order is detected at runtime.
+// YOLOv8 instance segmentation. Auto-detects the engine kind: raw outputs
+// (detections [1, 4+nc+seg_channels, anchors] + prototypes) → decode + NMS on the host;
+// YoloSegPostprocess plugin outputs (num_dets/bboxes/scores/labels/mask_coeffs + proto)
+// → NMS already done, gather coeffs only. Mask assembly is shared by both.
 class SegEngine: public Engine {
 public:
     SegEngine(const std::string& engine_path, const InferConfig& config): Engine(engine_path, config)
@@ -23,9 +25,98 @@ public:
     void postprocess(std::vector<Object>& objs) override
     {
         objs.clear();
+        if (binding_index("num_dets") >= 0) {
+            postprocess_plugin(objs);
+        }
+        else {
+            postprocess_raw(objs);
+        }
+    }
+
+    void draw(const cv::Mat& image, cv::Mat& res, const std::vector<Object>& objs) const override
+    {
+        draw_segments(image, res, objs, class_names_);
+    }
+
+private:
+    // Index of an output binding by name, or -1.
+    int binding_index(const std::string& name) const
+    {
+        for (size_t i = 0; i < output_bindings_.size(); ++i) {
+            if (output_bindings_[i].name == name) {
+                return static_cast<int>(i);
+            }
+        }
+        return -1;
+    }
+
+    // matmul kept coefficients with the prototypes, sigmoid, crop the padded region,
+    // resize to the original image and threshold. Shared by both postprocess paths.
+    void assemble_masks(std::vector<Object>& objs, const cv::Mat& masks, const cv::Mat& protos)
+    {
+        if (masks.empty()) {
+            return;
+        }
+        const int   seg_h = config_.seg_h, seg_w = config_.seg_w;
+        const int   input_h = input_bindings_[0].dims.d[2];
+        const int   input_w = input_bindings_[0].dims.d[3];
+        const float dw = pparam_.dw, dh = pparam_.dh;
+        const float width = pparam_.width, height = pparam_.height;
+
+        cv::Mat matmul   = (masks * protos).t();
+        cv::Mat mask_mat = matmul.reshape(static_cast<int>(objs.size()), {seg_h, seg_w});
+
+        std::vector<cv::Mat> mask_channels;
+        cv::split(mask_mat, mask_channels);
+        const int      scale_dw = dw / input_w * seg_w;
+        const int      scale_dh = dh / input_h * seg_h;
+        const cv::Rect roi(scale_dw, scale_dh, seg_w - 2 * scale_dw, seg_h - 2 * scale_dh);
+
+        for (size_t i = 0; i < objs.size(); ++i) {
+            cv::Mat dest, mask;
+            cv::exp(-mask_channels[i], dest);
+            dest = 1.0 / (1.0 + dest);
+            dest = dest(roi);
+            cv::resize(dest, mask, cv::Size(static_cast<int>(width), static_cast<int>(height)), cv::INTER_LINEAR);
+            objs[i].boxMask = mask(objs[i].rect) > 0.5f;
+        }
+    }
+
+    // Plugin engine: NMS + coeff gather done in-engine; only rescale + assemble masks.
+    void postprocess_plugin(std::vector<Object>& objs)
+    {
+        const int    seg_channels = config_.seg_channels;
+        const int*   num_dets     = static_cast<const int*>(host_ptrs_[binding_index("num_dets")]);
+        const float* boxes        = static_cast<const float*>(host_ptrs_[binding_index("bboxes")]);
+        const float* scores       = static_cast<const float*>(host_ptrs_[binding_index("scores")]);
+        const int*   labels       = static_cast<const int*>(host_ptrs_[binding_index("labels")]);
+        const float* coeffs       = static_cast<const float*>(host_ptrs_[binding_index("mask_coeffs")]);
+        cv::Mat      protos(seg_channels, config_.seg_h * config_.seg_w, CV_32F, host_ptrs_[binding_index("proto")]);
+        const float  dw = pparam_.dw, dh = pparam_.dh;
+        const float  width = pparam_.width, height = pparam_.height, ratio = pparam_.ratio;
+
+        cv::Mat masks;
+        for (int i = 0; i < num_dets[0]; ++i) {
+            const float* ptr = boxes + i * 4;
+            const float  x0  = clamp((ptr[0] - dw) * ratio, 0.f, width);
+            const float  y0  = clamp((ptr[1] - dh) * ratio, 0.f, height);
+            const float  x1  = clamp((ptr[2] - dw) * ratio, 0.f, width);
+            const float  y1  = clamp((ptr[3] - dh) * ratio, 0.f, height);
+
+            Object obj;
+            obj.rect  = cv::Rect_<float>(x0, y0, x1 - x0, y1 - y0);
+            obj.prob  = scores[i];
+            obj.label = labels[i];
+            objs.push_back(obj);
+            masks.push_back(cv::Mat(1, seg_channels, CV_32F, const_cast<float*>(coeffs + i * seg_channels)));
+        }
+        assemble_masks(objs, masks, protos);
+    }
+
+    // Raw engine: detections [1, 4+nc+seg_channels, anchors] + prototypes; decode + NMS.
+    void postprocess_raw(std::vector<Object>& objs)
+    {
         const int seg_channels = config_.seg_channels, seg_h = config_.seg_h, seg_w = config_.seg_w;
-        const int input_h = input_bindings_[0].dims.d[2];
-        const int input_w = input_bindings_[0].dims.d[3];
 
         // Find the 3-D detection output; the other output holds the prototypes.
         int det_idx      = -1;
@@ -97,35 +188,9 @@ public:
             objs.push_back(obj);
             ++cnt;
         }
-
-        if (masks.empty()) {
-            return;
-        }
-        cv::Mat matmul   = (masks * protos).t();
-        cv::Mat mask_mat = matmul.reshape(static_cast<int>(objs.size()), {seg_h, seg_w});
-
-        std::vector<cv::Mat> mask_channels;
-        cv::split(mask_mat, mask_channels);
-        const int      scale_dw = dw / input_w * seg_w;
-        const int      scale_dh = dh / input_h * seg_h;
-        const cv::Rect roi(scale_dw, scale_dh, seg_w - 2 * scale_dw, seg_h - 2 * scale_dh);
-
-        for (size_t i = 0; i < objs.size(); ++i) {
-            cv::Mat dest, mask;
-            cv::exp(-mask_channels[i], dest);
-            dest = 1.0 / (1.0 + dest);
-            dest = dest(roi);
-            cv::resize(dest, mask, cv::Size(static_cast<int>(width), static_cast<int>(height)), cv::INTER_LINEAR);
-            objs[i].boxMask = mask(objs[i].rect) > 0.5f;
-        }
+        assemble_masks(objs, masks, protos);
     }
 
-    void draw(const cv::Mat& image, cv::Mat& res, const std::vector<Object>& objs) const override
-    {
-        draw_segments(image, res, objs, class_names_);
-    }
-
-private:
     std::vector<std::string> class_names_;
 };
 

--- a/csrc/core/CMakeLists.txt
+++ b/csrc/core/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(yolov8_core PUBLIC
     CUDA::cudart
     ${OpenCV_LIBS}
     TensorRT::TensorRT
+    ${CMAKE_DL_LIBS}  # dlopen for custom plugin .so
 )
 
 # GPU preprocessing kernel (opt-in). Compiled into the core lib only when the root

--- a/csrc/core/CMakeLists.txt
+++ b/csrc/core/CMakeLists.txt
@@ -26,10 +26,19 @@ target_link_libraries(yolov8_core PUBLIC
     TensorRT::TensorRT
 )
 
+# GPU preprocessing kernel (opt-in). Compiled into the core lib only when the root
+# build found a CUDA compiler; otherwise the engine's --gpu-preprocess branch throws.
+if(YOLOV8_GPU_PREPROCESS)
+    target_sources(yolov8_core PRIVATE src/preprocess.cu)
+    target_compile_definitions(yolov8_core PUBLIC YOLOV8_GPU_PREPROCESS)
+    set_target_properties(yolov8_core PROPERTIES CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
+endif()
+
 # Require at least C++14 (the ghc::filesystem floor); the project default is C++17
 # (std::filesystem). Build with -DCMAKE_CXX_STANDARD=14 to exercise the ghc fallback.
 target_compile_features(yolov8_core PUBLIC cxx_std_14)
-target_compile_options(yolov8_core PRIVATE -Wall -Wextra)
+# Warning flags only for C++ TUs (nvcc rejects -Wall/-Wextra passed directly).
+target_compile_options(yolov8_core PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wall;-Wextra>)
 
 # TRT_10 / BATCHED_NMS are PUBLIC so task executables compile the same code paths.
 yolov8_apply_compile_defs(yolov8_core)

--- a/csrc/core/include/yolov8/config.hpp
+++ b/csrc/core/include/yolov8/config.hpp
@@ -15,6 +15,7 @@ struct InferConfig {
     int         seg_h        = 160;
     int         seg_w        = 160;
     std::string labels_path;  // empty -> built-in COCO names
+    std::string plugin_lib;   // custom plugin .so to dlopen (else $YOLOV8_PLUGIN_LIB)
     bool        warmup         = true;
     bool        show           = false;  // off by default (works headless); otherwise save
     bool        profile        = false;  // attach a per-layer IProfiler and print a report

--- a/csrc/core/include/yolov8/config.hpp
+++ b/csrc/core/include/yolov8/config.hpp
@@ -15,10 +15,11 @@ struct InferConfig {
     int         seg_h        = 160;
     int         seg_w        = 160;
     std::string labels_path;  // empty -> built-in COCO names
-    bool        warmup  = true;
-    bool        show    = false;  // off by default (works headless); otherwise save
-    bool        profile = false;  // attach a per-layer IProfiler and print a report
-    std::string out_dir = "output";
+    bool        warmup         = true;
+    bool        show           = false;  // off by default (works headless); otherwise save
+    bool        profile        = false;  // attach a per-layer IProfiler and print a report
+    bool        gpu_preprocess = false;  // preprocess on GPU (CUDA kernel) instead of CPU/OpenCV
+    std::string out_dir        = "output";
 };
 
 struct CliArgs {

--- a/csrc/core/include/yolov8/engine.hpp
+++ b/csrc/core/include/yolov8/engine.hpp
@@ -38,8 +38,13 @@ public:
     void print_profile() const;  // prints the per-layer report if --profile was set
 
 protected:
-    // Preprocess one image into an NCHW blob. Default is letterbox; cls overrides it.
+    // Preprocess one image into an NCHW blob (CPU path). Default is letterbox; cls overrides it.
     virtual void preprocess(const cv::Mat& image, cv::Mat& blob);
+    // Whether the GPU preprocess path should letterbox (true) or plain-resize (false, cls).
+    virtual bool letterbox_preproc() const
+    {
+        return true;
+    }
 
     InferConfig          config_;
     std::vector<Binding> input_bindings_;
@@ -53,7 +58,9 @@ private:
     // Declared so destruction runs context -> engine -> runtime -> stream -> buffers.
     std::vector<DeviceBuffer>                 device_buffers_;
     std::vector<HostPinnedBuffer>             host_buffers_;
-    std::vector<void*>                        device_ptrs_;  // [inputs..., outputs...]
+    std::vector<void*>                        device_ptrs_;     // [inputs..., outputs...]
+    DeviceBuffer                              raw_input_;       // uint8 device buffer for --gpu-preprocess
+    HostPinnedBuffer                          raw_input_host_;  // pinned staging for a fast async H2D upload
     CudaStream                                stream_;
     TrtUniquePtr<nvinfer1::IRuntime>          runtime_;
     TrtUniquePtr<nvinfer1::ICudaEngine>       engine_;

--- a/csrc/core/include/yolov8/preprocess.hpp
+++ b/csrc/core/include/yolov8/preprocess.hpp
@@ -11,4 +11,14 @@ void letterbox(const cv::Mat& image, cv::Mat& out, const cv::Size& size, PrePara
 // Plain resize (no padding) into an NCHW float blob (RGB, /255). Used for classification.
 void resize_blob(const cv::Mat& image, cv::Mat& out, const cv::Size& size, PreParam& pparam);
 
+// GPU counterparts (defined in preprocess.cu, compiled only when CUDA is available).
+// `src` is a device-side uint8 HWC BGR image; `dst` is the device NCHW float input
+// buffer (RGB, /255) written directly. `stream` is a cudaStream_t passed as void* to
+// keep this header free of CUDA headers. Records scale/pad in `pparam` exactly like
+// the CPU versions above.
+void letterbox_cuda(
+    const unsigned char* src, int src_w, int src_h, float* dst, int dst_w, int dst_h, PreParam& pparam, void* stream);
+void resize_cuda(
+    const unsigned char* src, int src_w, int src_h, float* dst, int dst_w, int dst_h, PreParam& pparam, void* stream);
+
 }  // namespace yolov8

--- a/csrc/core/src/config.cpp
+++ b/csrc/core/src/config.cpp
@@ -26,6 +26,7 @@ namespace {
               << "  --out-dir <dir>   output directory (default \"" << d.out_dir << "\")\n"
               << "  --show            display results in a window instead of saving\n"
               << "  --profile         print a per-layer timing report\n"
+              << "  --gpu-preprocess  preprocess on the GPU (CUDA kernel) instead of CPU/OpenCV\n"
               << "  --no-warmup       skip warmup iterations\n"
               << "  -h, --help        show this help\n";
     std::exit(code);
@@ -99,6 +100,9 @@ CliArgs parse_args(int argc, char** argv, const InferConfig& defaults)
         }
         else if (a == "--profile") {
             args.config.profile = true;
+        }
+        else if (a == "--gpu-preprocess") {
+            args.config.gpu_preprocess = true;
         }
         else if (a == "--no-warmup") {
             args.config.warmup = false;

--- a/csrc/core/src/config.cpp
+++ b/csrc/core/src/config.cpp
@@ -21,6 +21,7 @@ namespace {
               << "  --iou <f>         NMS IoU threshold (default " << d.iou_thres << ")\n"
               << "  --topk <n>        max detections (default " << d.topk << ")\n"
               << "  --labels <path>   class-names file, one per line (default: built-in COCO)\n"
+              << "  --plugin-lib <p>  custom TensorRT plugin .so to load (else $YOLOV8_PLUGIN_LIB)\n"
               << "  --seg-channels <n> mask prototype channels (default " << d.seg_channels << ")\n"
               << "  --seg-hw <h> <w>  mask prototype size (default " << d.seg_h << " " << d.seg_w << ")\n"
               << "  --out-dir <dir>   output directory (default \"" << d.out_dir << "\")\n"
@@ -84,6 +85,9 @@ CliArgs parse_args(int argc, char** argv, const InferConfig& defaults)
         }
         else if (a == "--labels") {
             args.config.labels_path = next("--labels");
+        }
+        else if (a == "--plugin-lib") {
+            args.config.plugin_lib = next("--plugin-lib");
         }
         else if (a == "--seg-channels") {
             args.config.seg_channels = to_int(next("--seg-channels"), "--seg-channels");

--- a/csrc/core/src/engine.cpp
+++ b/csrc/core/src/engine.cpp
@@ -4,6 +4,7 @@
 #include "yolov8/logger.hpp"
 #include "yolov8/preprocess.hpp"
 #include "yolov8/trt_compat.hpp"
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <vector>
@@ -117,12 +118,45 @@ void Engine::preprocess(const cv::Mat& image, cv::Mat& blob)
 
 void Engine::copy_from_mat(const cv::Mat& image)
 {
-    cv::Mat blob;
-    preprocess(image, blob);
-
     const auto& in = input_bindings_[0];
-    CUDA_CHECK(cudaMemcpyAsync(
-        device_ptrs_[0], blob.ptr<float>(), blob.total() * blob.elemSize(), cudaMemcpyHostToDevice, stream_.get()));
+
+    if (config_.gpu_preprocess) {
+#ifdef YOLOV8_GPU_PREPROCESS
+        // Upload the raw uint8 BGR image and let a CUDA kernel produce the NCHW float
+        // blob directly in the input buffer — no CPU letterbox/blob. Stage through a
+        // pinned host buffer so the H2D copy is truly async (pageable memory is not).
+        cv::Mat      src   = image.isContinuous() ? image : image.clone();
+        const size_t bytes = src.total() * src.elemSize();
+        if (raw_input_host_.bytes() < bytes) {
+            raw_input_host_ = HostPinnedBuffer(bytes);  // grow (move-assign frees the old buffer)
+        }
+        if (raw_input_.bytes() < bytes) {
+            raw_input_ = DeviceBuffer(bytes);
+        }
+        std::memcpy(raw_input_host_.data(), src.data, bytes);
+        CUDA_CHECK(
+            cudaMemcpyAsync(raw_input_.data(), raw_input_host_.data(), bytes, cudaMemcpyHostToDevice, stream_.get()));
+        auto*       dst = static_cast<float*>(device_ptrs_[0]);
+        const int   dw = config_.input_size.width, dh = config_.input_size.height;
+        const auto* raw = static_cast<const unsigned char*>(raw_input_.data());
+        if (letterbox_preproc()) {
+            letterbox_cuda(raw, src.cols, src.rows, dst, dw, dh, pparam_, stream_.get());
+        }
+        else {
+            resize_cuda(raw, src.cols, src.rows, dst, dw, dh, pparam_, stream_.get());
+        }
+        CUDA_CHECK(cudaGetLastError());
+#else
+        throw TrtException("--gpu-preprocess requires a CUDA-enabled build (no nvcc found at configure time)");
+#endif
+    }
+    else {
+        cv::Mat blob;
+        preprocess(image, blob);
+        CUDA_CHECK(cudaMemcpyAsync(
+            device_ptrs_[0], blob.ptr<float>(), blob.total() * blob.elemSize(), cudaMemcpyHostToDevice, stream_.get()));
+    }
+
     const nvinfer1::Dims4 shape{1, 3, config_.input_size.height, config_.input_size.width};
     compat::set_input_shape(context_.get(), 0, in.name, shape);
     compat::set_tensor_address(context_.get(), in.name, device_ptrs_[0]);

--- a/csrc/core/src/engine.cpp
+++ b/csrc/core/src/engine.cpp
@@ -4,7 +4,9 @@
 #include "yolov8/logger.hpp"
 #include "yolov8/preprocess.hpp"
 #include "yolov8/trt_compat.hpp"
+#include <cstdlib>
 #include <cstring>
+#include <dlfcn.h>
 #include <fstream>
 #include <iostream>
 #include <vector>
@@ -26,6 +28,16 @@ void Engine::load_engine(const std::string& engine_path)
     std::vector<char> blob(static_cast<size_t>(size));
     TRT_CHECK(file.read(blob.data(), size).good());
     file.close();
+
+    // Load a custom plugin .so (if any) before plugin init / deserialize so its
+    // creators are registered. Path from --plugin-lib or $YOLOV8_PLUGIN_LIB.
+    const char* plugin_lib =
+        !config_.plugin_lib.empty() ? config_.plugin_lib.c_str() : std::getenv("YOLOV8_PLUGIN_LIB");
+    if (plugin_lib && *plugin_lib) {
+        if (!dlopen(plugin_lib, RTLD_NOW | RTLD_GLOBAL)) {
+            throw TrtException(std::string("failed to load plugin library '") + plugin_lib + "': " + dlerror());
+        }
+    }
 
     initLibNvInferPlugins(&global_logger(), "");
     runtime_.reset(nvinfer1::createInferRuntime(global_logger()));

--- a/csrc/core/src/preprocess.cu
+++ b/csrc/core/src/preprocess.cu
@@ -1,0 +1,159 @@
+// GPU preprocessing: turn a raw uint8 HWC BGR image straight into the NCHW float
+// blob the network expects (RGB, /255), with optional letterbox padding. This is
+// the opt-in counterpart to the CPU path in preprocess.cpp; the host-side scalar
+// math (ratio/dw/dh) is kept identical so pparam_ — and thus postprocess box
+// rescaling — is unchanged. Bilinear sampling is not bit-identical to cv::resize,
+// so results match within tolerance, not byte-for-byte.
+
+#include "yolov8/preprocess.hpp"
+#include <cmath>
+#include <cuda_runtime.h>
+
+namespace yolov8 {
+
+namespace {
+
+// One thread per destination pixel. Outside the resized ROI we write the 114 pad
+// value; inside we bilinearly sample the source (cv::resize INTER_LINEAR mapping).
+__global__ void blob_kernel(const unsigned char* src,
+                            int                  src_w,
+                            int                  src_h,
+                            float*               dst,
+                            int                  dst_w,
+                            int                  dst_h,
+                            int                  roi_x,
+                            int                  roi_y,
+                            int                  roi_w,
+                            int                  roi_h,
+                            float                scale_x,
+                            float                scale_y)
+{
+    const int dx = blockIdx.x * blockDim.x + threadIdx.x;
+    const int dy = blockIdx.y * blockDim.y + threadIdx.y;
+    if (dx >= dst_w || dy >= dst_h) {
+        return;
+    }
+
+    const int plane = dst_w * dst_h;
+    const int idx   = dy * dst_w + dx;
+    const int rx    = dx - roi_x;
+    const int ry    = dy - roi_y;
+
+    if (rx < 0 || rx >= roi_w || ry < 0 || ry >= roi_h) {
+        const float pad      = 114.0f / 255.0f;
+        dst[0 * plane + idx] = pad;
+        dst[1 * plane + idx] = pad;
+        dst[2 * plane + idx] = pad;
+        return;
+    }
+
+    float sx = (rx + 0.5f) * scale_x - 0.5f;
+    float sy = (ry + 0.5f) * scale_y - 0.5f;
+    sx       = sx < 0.0f ? 0.0f : (sx > src_w - 1 ? src_w - 1 : sx);
+    sy       = sy < 0.0f ? 0.0f : (sy > src_h - 1 ? src_h - 1 : sy);
+
+    const int   x0  = static_cast<int>(sx);
+    const int   y0  = static_cast<int>(sy);
+    const int   x1  = x0 + 1 < src_w ? x0 + 1 : x0;
+    const int   y1  = y0 + 1 < src_h ? y0 + 1 : y0;
+    const float ax  = sx - x0;
+    const float ay  = sy - y0;
+    const float w00 = (1.0f - ax) * (1.0f - ay);
+    const float w01 = ax * (1.0f - ay);
+    const float w10 = (1.0f - ax) * ay;
+    const float w11 = ax * ay;
+
+    const unsigned char* p00 = src + (y0 * src_w + x0) * 3;
+    const unsigned char* p01 = src + (y0 * src_w + x1) * 3;
+    const unsigned char* p10 = src + (y1 * src_w + x0) * 3;
+    const unsigned char* p11 = src + (y1 * src_w + x1) * 3;
+
+    // Source is BGR (channel c: 0=B,1=G,2=R); output plane order is RGB, so
+    // channel c lands in plane (2 - c) — matching to_blob() in preprocess.cpp.
+#pragma unroll
+    for (int c = 0; c < 3; ++c) {
+        const float v              = w00 * p00[c] + w01 * p01[c] + w10 * p10[c] + w11 * p11[c];
+        dst[(2 - c) * plane + idx] = v / 255.0f;
+    }
+}
+
+void launch(const unsigned char* src,
+            int                  src_w,
+            int                  src_h,
+            float*               dst,
+            int                  dst_w,
+            int                  dst_h,
+            int                  roi_x,
+            int                  roi_y,
+            int                  roi_w,
+            int                  roi_h,
+            float                scale_x,
+            float                scale_y,
+            cudaStream_t         stream)
+{
+    const dim3 block(16, 16);
+    const dim3 grid((dst_w + block.x - 1) / block.x, (dst_h + block.y - 1) / block.y);
+    blob_kernel<<<grid, block, 0, stream>>>(
+        src, src_w, src_h, dst, dst_w, dst_h, roi_x, roi_y, roi_w, roi_h, scale_x, scale_y);
+}
+
+}  // namespace
+
+void letterbox_cuda(
+    const unsigned char* src, int src_w, int src_h, float* dst, int dst_w, int dst_h, PreParam& pparam, void* stream)
+{
+    // Identical scalar math to preprocess.cpp::letterbox so pparam stays the same.
+    const float r    = std::min(static_cast<float>(dst_h) / src_h, static_cast<float>(dst_w) / src_w);
+    const int   padw = static_cast<int>(std::round(src_w * r));
+    const int   padh = static_cast<int>(std::round(src_h * r));
+    const float dw   = (dst_w - padw) / 2.0f;
+    const float dh   = (dst_h - padh) / 2.0f;
+    const int   left = static_cast<int>(std::round(dw - 0.1f));
+    const int   top  = static_cast<int>(std::round(dh - 0.1f));
+
+    launch(src,
+           src_w,
+           src_h,
+           dst,
+           dst_w,
+           dst_h,
+           left,
+           top,
+           padw,
+           padh,
+           static_cast<float>(src_w) / padw,
+           static_cast<float>(src_h) / padh,
+           static_cast<cudaStream_t>(stream));
+
+    pparam.ratio  = 1.0f / r;
+    pparam.dw     = dw;
+    pparam.dh     = dh;
+    pparam.height = src_h;
+    pparam.width  = src_w;
+}
+
+void resize_cuda(
+    const unsigned char* src, int src_w, int src_h, float* dst, int dst_w, int dst_h, PreParam& pparam, void* stream)
+{
+    launch(src,
+           src_w,
+           src_h,
+           dst,
+           dst_w,
+           dst_h,
+           0,
+           0,
+           dst_w,
+           dst_h,
+           static_cast<float>(src_w) / dst_w,
+           static_cast<float>(src_h) / dst_h,
+           static_cast<cudaStream_t>(stream));
+
+    pparam.ratio  = 1.0f;
+    pparam.dw     = 0.0f;
+    pparam.dh     = 0.0f;
+    pparam.height = src_h;
+    pparam.width  = src_w;
+}
+
+}  // namespace yolov8

--- a/csrc/plugins/CMakeLists.txt
+++ b/csrc/plugins/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Custom TensorRT postprocess plugins (libyolov8_plugins.so). Like the engine, the
+# .so is tied to the TensorRT version it is built against — build it with the same
+# -DTensorRT_ROOT you use for the engine. Off by default (-DBUILD_PLUGINS=ON); needs
+# the CUDA language (enabled by the root build when nvcc is found).
+add_library(yolov8_plugins SHARED
+    src/det_plugin.cu
+)
+
+set_target_properties(yolov8_plugins PROPERTIES
+    CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}"
+    POSITION_INDEPENDENT_CODE ON
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+target_include_directories(yolov8_plugins PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+target_link_libraries(yolov8_plugins PRIVATE CUDA::cudart TensorRT::TensorRT)
+
+# IPluginV2DynamicExt is deprecated on TRT 10/11 but still the single-source API that
+# also works on TRT 8 — silence the deprecation noise for this target only.
+target_compile_options(yolov8_plugins PRIVATE
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>
+    # 997: dynamic-API methods intentionally hide the legacy IPluginV2 overloads.
+    $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-Wno-deprecated-declarations;--diag-suppress=997>
+)

--- a/csrc/plugins/CMakeLists.txt
+++ b/csrc/plugins/CMakeLists.txt
@@ -5,6 +5,7 @@
 add_library(yolov8_plugins SHARED
     src/det_plugin.cu
     src/seg_plugin.cu
+    src/pose_plugin.cu
 )
 
 set_target_properties(yolov8_plugins PROPERTIES

--- a/csrc/plugins/CMakeLists.txt
+++ b/csrc/plugins/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(yolov8_plugins SHARED
     src/det_plugin.cu
     src/seg_plugin.cu
     src/pose_plugin.cu
+    src/obb_plugin.cu
 )
 
 set_target_properties(yolov8_plugins PROPERTIES

--- a/csrc/plugins/CMakeLists.txt
+++ b/csrc/plugins/CMakeLists.txt
@@ -4,6 +4,7 @@
 # the CUDA language (enabled by the root build when nvcc is found).
 add_library(yolov8_plugins SHARED
     src/det_plugin.cu
+    src/seg_plugin.cu
 )
 
 set_target_properties(yolov8_plugins PROPERTIES

--- a/csrc/plugins/src/det_plugin.cu
+++ b/csrc/plugins/src/det_plugin.cu
@@ -1,0 +1,406 @@
+// YoloDetPostprocess — a TensorRT plugin that fuses YOLOv8 detection
+// score-threshold + NMS + top-k on the GPU. It consumes the already-decoded head
+// outputs (corner boxes + per-class scores, exactly what models/common.py PostDetect
+// feeds EfficientNMS_TRT) and emits the same four tensors as EfficientNMS_TRT, so it
+// is a drop-in alternative. Built into libyolov8_plugins.so and registered via
+// REGISTER_TENSORRT_PLUGIN. Implemented against IPluginV2DynamicExt, whose API is
+// stable across TensorRT 8 / 10 / 11 (deprecated on 10+ but functional).
+
+#include "NvInferPlugin.h"
+#include <cstring>
+#include <cub/device/device_radix_sort.cuh>
+#include <cuda_runtime.h>
+#include <string>
+#include <vector>
+
+namespace {
+
+const char* kPluginName    = "YoloDetPostprocess";
+const char* kPluginVersion = "1";
+
+struct DetParams {
+    float score_threshold  = 0.25f;
+    float iou_threshold    = 0.65f;
+    int   max_output       = 100;  // top-k
+    int   background       = -1;   // unused (kept for EfficientNMS attribute parity)
+    int   box_coding       = 0;    // 0 = corner [x1,y1,x2,y2] (the only mode we emit)
+    int   score_activation = 0;    // scores already sigmoided upstream
+};
+
+// ---- device helpers --------------------------------------------------------
+
+__device__ inline float iou_xyxy(const float* a, const float* b)
+{
+    const float ix0    = fmaxf(a[0], b[0]);
+    const float iy0    = fmaxf(a[1], b[1]);
+    const float ix1    = fminf(a[2], b[2]);
+    const float iy1    = fminf(a[3], b[3]);
+    const float iw     = fmaxf(0.0f, ix1 - ix0);
+    const float ih     = fmaxf(0.0f, iy1 - iy0);
+    const float inter  = iw * ih;
+    const float area_a = fmaxf(0.0f, a[2] - a[0]) * fmaxf(0.0f, a[3] - a[1]);
+    const float area_b = fmaxf(0.0f, b[2] - b[0]) * fmaxf(0.0f, b[3] - b[1]);
+    const float uni    = area_a + area_b - inter;
+    return uni > 0.0f ? inter / uni : 0.0f;
+}
+
+// Per-anchor argmax over the class channels.
+__global__ void argmax_kernel(const float* scores, int num_anchors, int num_classes, float* best_score, int* best_cls)
+{
+    const int a = blockIdx.x * blockDim.x + threadIdx.x;
+    if (a >= num_anchors) {
+        return;
+    }
+    const float* s    = scores + static_cast<size_t>(a) * num_classes;
+    float        best = s[0];
+    int          bi   = 0;
+    for (int c = 1; c < num_classes; ++c) {
+        if (s[c] > best) {
+            best = s[c];
+            bi   = c;
+        }
+    }
+    best_score[a] = best;
+    best_cls[a]   = bi;
+}
+
+__global__ void iota_kernel(int* v, int n)
+{
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) {
+        v[i] = i;
+    }
+}
+
+// Single-thread greedy NMS over score-sorted anchors (class-aware: only same-class
+// boxes suppress each other). Anchor count after threshold is small, so this is cheap.
+__global__ void nms_kernel(const float* boxes,
+                           const float* sorted_score,
+                           const int*   sorted_idx,
+                           const int*   cls,
+                           int          num_anchors,
+                           float        score_thr,
+                           float        iou_thr,
+                           int          topk,
+                           int*         num_dets,
+                           float*       out_boxes,
+                           float*       out_scores,
+                           int*         out_classes)
+{
+    int keep = 0;
+    for (int r = 0; r < num_anchors && keep < topk; ++r) {
+        const float sc = sorted_score[r];
+        if (sc <= score_thr) {
+            break;  // sorted descending: nothing else can pass
+        }
+        const int    a  = sorted_idx[r];
+        const float* bx = boxes + static_cast<size_t>(a) * 4;
+        const int    cl = cls[a];
+
+        bool suppressed = false;
+        for (int k = 0; k < keep; ++k) {
+            if (out_classes[k] == cl && iou_xyxy(bx, out_boxes + k * 4) > iou_thr) {
+                suppressed = true;
+                break;
+            }
+        }
+        if (!suppressed) {
+            out_boxes[keep * 4 + 0] = bx[0];
+            out_boxes[keep * 4 + 1] = bx[1];
+            out_boxes[keep * 4 + 2] = bx[2];
+            out_boxes[keep * 4 + 3] = bx[3];
+            out_scores[keep]        = sc;
+            out_classes[keep]       = cl;
+            ++keep;
+        }
+    }
+    *num_dets = keep;
+}
+
+// ---- plugin ----------------------------------------------------------------
+
+class YoloDetPostprocess: public nvinfer1::IPluginV2DynamicExt {
+public:
+    explicit YoloDetPostprocess(DetParams p): params_(p) {}
+    YoloDetPostprocess(const void* data, size_t length)
+    {
+        const char* p = static_cast<const char*>(data);
+        std::memcpy(&params_, p, sizeof(DetParams));
+        (void)length;
+    }
+    YoloDetPostprocess(const YoloDetPostprocess&) = default;
+
+    // IPluginV2DynamicExt
+    nvinfer1::IPluginV2DynamicExt* clone() const noexcept override
+    {
+        auto* q = new YoloDetPostprocess(*this);
+        q->setPluginNamespace(namespace_.c_str());
+        return q;
+    }
+
+    nvinfer1::DimsExprs getOutputDimensions(int32_t                    outputIndex,
+                                            const nvinfer1::DimsExprs* inputs,
+                                            int32_t                    nbInputs,
+                                            nvinfer1::IExprBuilder&    expr) noexcept override
+    {
+        (void)nbInputs;
+        nvinfer1::DimsExprs out;
+        const auto*         batch = inputs[0].d[0];
+        const auto*         topk  = expr.constant(params_.max_output);
+        if (outputIndex == 0) {  // num_dets [B, 1]
+            out.nbDims = 2;
+            out.d[0]   = batch;
+            out.d[1]   = expr.constant(1);
+        }
+        else if (outputIndex == 1) {  // boxes [B, topk, 4]
+            out.nbDims = 3;
+            out.d[0]   = batch;
+            out.d[1]   = topk;
+            out.d[2]   = expr.constant(4);
+        }
+        else {  // scores [B, topk] / classes [B, topk]
+            out.nbDims = 2;
+            out.d[0]   = batch;
+            out.d[1]   = topk;
+        }
+        return out;
+    }
+
+    bool supportsFormatCombination(int32_t                           pos,
+                                   const nvinfer1::PluginTensorDesc* inOut,
+                                   int32_t                           nbInputs,
+                                   int32_t                           nbOutputs) noexcept override
+    {
+        (void)nbInputs;
+        (void)nbOutputs;
+        const auto& d = inOut[pos];
+        if (d.format != nvinfer1::TensorFormat::kLINEAR) {
+            return false;
+        }
+        // inputs 0,1 float; outputs: 0 int32 (num_dets), 1 float (boxes), 2 float (scores), 3 int32 (classes)
+        if (pos == 2 || pos == 5) {
+            return d.type == nvinfer1::DataType::kINT32;
+        }
+        return d.type == nvinfer1::DataType::kFLOAT;
+    }
+
+    void configurePlugin(const nvinfer1::DynamicPluginTensorDesc*,
+                         int32_t,
+                         const nvinfer1::DynamicPluginTensorDesc*,
+                         int32_t) noexcept override
+    {
+    }
+
+    // Workspace: 5 int/float arrays of length A (keys in/out, idx in/out, class) plus
+    // cub's radix-sort temp storage. cub with pre-allocated temp is CUDA-graph/stream-
+    // capture safe (no host sync, no implicit allocation) — thrust's sort is not.
+    size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
+                            int32_t                           nbInputs,
+                            const nvinfer1::PluginTensorDesc*,
+                            int32_t) const noexcept override
+    {
+        (void)nbInputs;
+        const int A = inputs[1].dims.d[1];
+        return arrays_bytes(A) + cub_temp_bytes(A);
+    }
+
+    int32_t enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
+                    const nvinfer1::PluginTensorDesc*,
+                    const void* const* inputs,
+                    void* const*       outputs,
+                    void*              workspace,
+                    cudaStream_t       stream) noexcept override
+    {
+        const int B  = inputDesc[0].dims.d[0];
+        const int A  = inputDesc[1].dims.d[1];
+        const int nc = inputDesc[1].dims.d[2];
+
+        const float* boxes       = static_cast<const float*>(inputs[0]);
+        const float* scores      = static_cast<const float*>(inputs[1]);
+        int*         num_dets    = static_cast<int*>(outputs[0]);
+        float*       out_boxes   = static_cast<float*>(outputs[1]);
+        float*       out_scores  = static_cast<float*>(outputs[2]);
+        int*         out_classes = static_cast<int*>(outputs[3]);
+
+        char*  ws       = static_cast<char*>(workspace);
+        float* keys_in  = reinterpret_cast<float*>(ws);
+        float* keys_out = keys_in + A;
+        int*   idx_in   = reinterpret_cast<int*>(keys_out + A);
+        int*   idx_out  = idx_in + A;
+        int*   cls_buf  = idx_out + A;
+        void*  temp     = ws + arrays_bytes(A);
+        size_t temp_sz  = cub_temp_bytes(A);
+
+        const int block = 256;
+        const int grid  = (A + block - 1) / block;
+        for (int b = 0; b < B; ++b) {
+            argmax_kernel<<<grid, block, 0, stream>>>(
+                scores + static_cast<size_t>(b) * A * nc, A, nc, keys_in, cls_buf);
+            iota_kernel<<<grid, block, 0, stream>>>(idx_in, A);
+            cub::DeviceRadixSort::SortPairsDescending(
+                temp, temp_sz, keys_in, keys_out, idx_in, idx_out, A, 0, sizeof(float) * 8, stream);
+            nms_kernel<<<1, 1, 0, stream>>>(boxes + static_cast<size_t>(b) * A * 4,
+                                            keys_out,
+                                            idx_out,
+                                            cls_buf,
+                                            A,
+                                            params_.score_threshold,
+                                            params_.iou_threshold,
+                                            params_.max_output,
+                                            num_dets + b,
+                                            out_boxes + static_cast<size_t>(b) * params_.max_output * 4,
+                                            out_scores + static_cast<size_t>(b) * params_.max_output,
+                                            out_classes + static_cast<size_t>(b) * params_.max_output);
+        }
+        return cudaGetLastError() == cudaSuccess ? 0 : -1;
+    }
+
+    // IPluginV2Ext
+    nvinfer1::DataType getOutputDataType(int32_t index, const nvinfer1::DataType*, int32_t) const noexcept override
+    {
+        return (index == 0 || index == 3) ? nvinfer1::DataType::kINT32 : nvinfer1::DataType::kFLOAT;
+    }
+
+    // IPluginV2
+    const char* getPluginType() const noexcept override
+    {
+        return kPluginName;
+    }
+    const char* getPluginVersion() const noexcept override
+    {
+        return kPluginVersion;
+    }
+    int32_t getNbOutputs() const noexcept override
+    {
+        return 4;
+    }
+    int32_t initialize() noexcept override
+    {
+        return 0;
+    }
+    void   terminate() noexcept override {}
+    size_t getSerializationSize() const noexcept override
+    {
+        return sizeof(DetParams);
+    }
+    void serialize(void* buffer) const noexcept override
+    {
+        std::memcpy(buffer, &params_, sizeof(DetParams));
+    }
+    void destroy() noexcept override
+    {
+        delete this;
+    }
+    void setPluginNamespace(const char* ns) noexcept override
+    {
+        namespace_ = ns ? ns : "";
+    }
+    const char* getPluginNamespace() const noexcept override
+    {
+        return namespace_.c_str();
+    }
+
+private:
+    // 5 length-A arrays (keys in/out float, idx in/out int, class int), 256-aligned.
+    static size_t arrays_bytes(int A)
+    {
+        const size_t b = static_cast<size_t>(A) * (2 * sizeof(float) + 3 * sizeof(int));
+        return (b + 255) & ~static_cast<size_t>(255);
+    }
+    // cub radix-sort temp storage (host-only size query, no launch).
+    static size_t cub_temp_bytes(int A)
+    {
+        size_t t = 0;
+        cub::DeviceRadixSort::SortPairsDescending<float, int>(
+            nullptr, t, nullptr, nullptr, nullptr, nullptr, A, 0, sizeof(float) * 8, 0);
+        return (t + 255) & ~static_cast<size_t>(255);
+    }
+
+    DetParams   params_;
+    std::string namespace_;
+};
+
+class YoloDetPostprocessCreator: public nvinfer1::IPluginCreator {
+public:
+    YoloDetPostprocessCreator()
+    {
+        fields_ = {
+            {"score_threshold", nullptr, nvinfer1::PluginFieldType::kFLOAT32, 1},
+            {"iou_threshold", nullptr, nvinfer1::PluginFieldType::kFLOAT32, 1},
+            {"max_output_boxes", nullptr, nvinfer1::PluginFieldType::kINT32, 1},
+            {"background_class", nullptr, nvinfer1::PluginFieldType::kINT32, 1},
+            {"box_coding", nullptr, nvinfer1::PluginFieldType::kINT32, 1},
+            {"score_activation", nullptr, nvinfer1::PluginFieldType::kINT32, 1},
+        };
+        fc_.nbFields = static_cast<int>(fields_.size());
+        fc_.fields   = fields_.data();
+    }
+
+    const char* getPluginName() const noexcept override
+    {
+        return kPluginName;
+    }
+    const char* getPluginVersion() const noexcept override
+    {
+        return kPluginVersion;
+    }
+    const nvinfer1::PluginFieldCollection* getFieldNames() noexcept override
+    {
+        return &fc_;
+    }
+
+    nvinfer1::IPluginV2* createPlugin(const char*, const nvinfer1::PluginFieldCollection* fc) noexcept override
+    {
+        DetParams p;
+        for (int i = 0; i < fc->nbFields; ++i) {
+            const auto&       f    = fc->fields[i];
+            const std::string name = f.name;
+            if (name == "score_threshold") {
+                p.score_threshold = *static_cast<const float*>(f.data);
+            }
+            else if (name == "iou_threshold") {
+                p.iou_threshold = *static_cast<const float*>(f.data);
+            }
+            else if (name == "max_output_boxes") {
+                p.max_output = *static_cast<const int*>(f.data);
+            }
+            else if (name == "background_class") {
+                p.background = *static_cast<const int*>(f.data);
+            }
+            else if (name == "box_coding") {
+                p.box_coding = *static_cast<const int*>(f.data);
+            }
+            else if (name == "score_activation") {
+                p.score_activation = *static_cast<const int*>(f.data);
+            }
+        }
+        auto* plugin = new YoloDetPostprocess(p);
+        plugin->setPluginNamespace(namespace_.c_str());
+        return plugin;
+    }
+
+    nvinfer1::IPluginV2* deserializePlugin(const char*, const void* data, size_t length) noexcept override
+    {
+        auto* plugin = new YoloDetPostprocess(data, length);
+        plugin->setPluginNamespace(namespace_.c_str());
+        return plugin;
+    }
+
+    void setPluginNamespace(const char* ns) noexcept override
+    {
+        namespace_ = ns ? ns : "";
+    }
+    const char* getPluginNamespace() const noexcept override
+    {
+        return namespace_.c_str();
+    }
+
+private:
+    std::vector<nvinfer1::PluginField> fields_;
+    nvinfer1::PluginFieldCollection    fc_{};
+    std::string                        namespace_;
+};
+
+}  // namespace
+
+REGISTER_TENSORRT_PLUGIN(YoloDetPostprocessCreator);

--- a/csrc/plugins/src/nms_common.cuh
+++ b/csrc/plugins/src/nms_common.cuh
@@ -1,0 +1,122 @@
+// Shared device/host helpers for the YOLOv8 postprocess plugins (det/seg/obb/pose):
+// per-anchor class argmax, score sorting via cub (CUDA-graph/stream-capture safe —
+// thrust is not), and axis-aligned IoU. Kernels are `static` so each translation unit
+// in libyolov8_plugins.so gets its own copy without link clashes.
+#pragma once
+
+#include <cstddef>
+#include <cub/device/device_radix_sort.cuh>
+#include <cuda_runtime.h>
+
+namespace yolov8_plugin {
+
+__device__ inline float iou_xyxy(const float* a, const float* b)
+{
+    const float ix0    = fmaxf(a[0], b[0]);
+    const float iy0    = fmaxf(a[1], b[1]);
+    const float ix1    = fminf(a[2], b[2]);
+    const float iy1    = fminf(a[3], b[3]);
+    const float iw     = fmaxf(0.0f, ix1 - ix0);
+    const float ih     = fmaxf(0.0f, iy1 - iy0);
+    const float inter  = iw * ih;
+    const float area_a = fmaxf(0.0f, a[2] - a[0]) * fmaxf(0.0f, a[3] - a[1]);
+    const float area_b = fmaxf(0.0f, b[2] - b[0]) * fmaxf(0.0f, b[3] - b[1]);
+    const float uni    = area_a + area_b - inter;
+    return uni > 0.0f ? inter / uni : 0.0f;
+}
+
+// Per-anchor argmax over the class channels.
+static __global__ void
+argmax_kernel(const float* scores, int num_anchors, int num_classes, float* best_score, int* best_cls)
+{
+    const int a = blockIdx.x * blockDim.x + threadIdx.x;
+    if (a >= num_anchors) {
+        return;
+    }
+    const float* s    = scores + static_cast<size_t>(a) * num_classes;
+    float        best = s[0];
+    int          bi   = 0;
+    for (int c = 1; c < num_classes; ++c) {
+        if (s[c] > best) {
+            best = s[c];
+            bi   = c;
+        }
+    }
+    best_score[a] = best;
+    best_cls[a]   = bi;
+}
+
+static __global__ void iota_kernel(int* v, int n)
+{
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) {
+        v[i] = i;
+    }
+}
+
+// Parallel NMS suppression for corner (xyxy) boxes, one thread per score-sorted anchor:
+// flag[r] = 0 iff a higher-scoring same-class box overlaps anchor r > iou_thr (the
+// dependency-free parallel rule used by EfficientNMS). Used by the det and seg plugins;
+// pose/obb decode their boxes differently and provide their own suppression.
+static __global__ void suppress_xyxy_kernel(const float* boxes,
+                                            const float* sorted_score,
+                                            const int*   sorted_idx,
+                                            const int*   cls,
+                                            int          num_anchors,
+                                            float        score_thr,
+                                            float        iou_thr,
+                                            int*         flag)
+{
+    const int r = blockIdx.x * blockDim.x + threadIdx.x;
+    if (r >= num_anchors) {
+        return;
+    }
+    if (sorted_score[r] <= score_thr) {
+        flag[r] = 0;
+        return;
+    }
+    const int    a  = sorted_idx[r];
+    const float* bx = boxes + static_cast<size_t>(a) * 4;
+    const int    cl = cls[a];
+    for (int p = 0; p < r; ++p) {  // sorted desc: every p < r has score >= score[r]
+        const int ap = sorted_idx[p];
+        if (cls[ap] == cl && iou_xyxy(bx, boxes + static_cast<size_t>(ap) * 4) > iou_thr) {
+            flag[r] = 0;
+            return;
+        }
+    }
+    flag[r] = 1;
+}
+
+// Scratch layout shared by the plugins: keys in/out (float) + idx in/out + class +
+// keep-flag (int), all length A and 256-aligned, followed by cub's radix-sort temp.
+// The keep-flag holds the parallel-NMS survivor mask.
+inline size_t nms_arrays_bytes(int A)
+{
+    const size_t b = static_cast<size_t>(A) * (2 * sizeof(float) + 4 * sizeof(int));
+    return (b + 255) & ~static_cast<size_t>(255);
+}
+
+inline size_t nms_cub_temp_bytes(int A)
+{
+    size_t t = 0;
+    cub::DeviceRadixSort::SortPairsDescending<float, int>(
+        nullptr, t, nullptr, nullptr, nullptr, nullptr, A, 0, sizeof(float) * 8, 0);
+    return (t + 255) & ~static_cast<size_t>(255);
+}
+
+inline size_t nms_workspace_bytes(int A)
+{
+    return nms_arrays_bytes(A) + nms_cub_temp_bytes(A);
+}
+
+inline void sort_scores_desc(
+    void* workspace, int A, float* keys_in, float* keys_out, int* idx_in, int* idx_out, cudaStream_t stream)
+{
+    void*  temp    = static_cast<char*>(workspace) + nms_arrays_bytes(A);
+    size_t temp_sz = nms_cub_temp_bytes(A);
+    cub::DeviceRadixSort::SortPairsDescending(
+        temp, temp_sz, keys_in, keys_out, idx_in, idx_out, A, 0, sizeof(float) * 8, stream);
+}
+
+}  // namespace yolov8_plugin

--- a/csrc/plugins/src/obb_plugin.cu
+++ b/csrc/plugins/src/obb_plugin.cu
@@ -1,0 +1,447 @@
+// YoloObbPostprocess — oriented-bounding-box postprocess plugin. Like pose it takes the
+// single transposed raw head tensor [B, A, C] (C = 4 + nc + 1: xc,yc,w,h | nc scores |
+// angle in radians) and does argmax + NMS + top-k in-engine, but NMS uses ProbIoU (the
+// closed-form Gaussian overlap ultralytics itself uses for OBB), which is cheaper than
+// polygon intersection. Outputs center boxes + angle so the consumer can rebuild the rrect.
+
+#include "NvInferPlugin.h"
+#include "nms_common.cuh"
+#include <cmath>
+#include <cstring>
+#include <cuda_runtime.h>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace yolov8_plugin;  // iota_kernel, cub sort helpers
+
+const char* kPluginName    = "YoloObbPostprocess";
+const char* kPluginVersion = "1";
+
+struct ObbParams {
+    float score_threshold  = 0.25f;
+    float iou_threshold    = 0.65f;
+    int   max_output       = 100;
+    int   background       = -1;
+    int   box_coding       = 0;
+    int   score_activation = 0;
+};
+
+// ---- rotated IoU (ProbIoU) -------------------------------------------------
+// ultralytics computes OBB NMS overlap with ProbIoU (a closed-form probabilistic
+// IoU from the boxes' Gaussian covariances), not polygon intersection. It is both
+// cheaper (no clipping) and matches ultralytics' own postprocess. Verified to agree
+// with ultralytics.utils.metrics.batch_probiou to 5 decimals.
+
+__device__ inline void cov_matrix(float w, float h, float r, float& a, float& b, float& c)
+{
+    const float av = w * w / 12.0f, bv = h * h / 12.0f;
+    const float cr = cosf(r), sr = sinf(r);
+    a = av * cr * cr + bv * sr * sr;
+    b = av * sr * sr + bv * cr * cr;
+    c = (av - bv) * sr * cr;
+}
+
+// boxA/boxB = (cx,cy,w,h); angles in radians. Returns ProbIoU in [0,1].
+__device__ inline float iou_probiou(const float* boxA, float rA, const float* boxB, float rB)
+{
+    const float eps = 1e-7f;
+    float       a1, b1, c1, a2, b2, c2;
+    cov_matrix(boxA[2], boxA[3], rA, a1, b1, c1);
+    cov_matrix(boxB[2], boxB[3], rB, a2, b2, c2);
+    const float cx1 = boxA[0], cy1 = boxA[1], cx2 = boxB[0], cy2 = boxB[1];
+    const float denom = (a1 + a2) * (b1 + b2) - powf(c1 + c2, 2) + eps;
+
+    const float t1 = ((a1 + a2) * powf(cy1 - cy2, 2) + (b1 + b2) * powf(cx1 - cx2, 2)) / denom;
+    const float t2 = ((c1 + c2) * (cx2 - cx1) * (cy1 - cy2)) / denom;
+    const float t3 =
+        logf(((a1 + a2) * (b1 + b2) - powf(c1 + c2, 2))
+                 / (4.0f * sqrtf(fmaxf(a1 * b1 - c1 * c1, 0.0f)) * sqrtf(fmaxf(a2 * b2 - c2 * c2, 0.0f)) + eps)
+             + eps);
+    float bd = 0.25f * t1 + 0.5f * t2 + 0.5f * t3;
+    bd       = fmaxf(fminf(bd, 100.0f), eps);
+    return 1.0f - sqrtf(1.0f - expf(-bd) + eps);
+}
+
+// ---- kernels ---------------------------------------------------------------
+
+// Per-anchor argmax over the nc class channels of a row-major [A, C] tensor (offset 4).
+__global__ void obb_argmax_kernel(const float* data, int A, int C, int nc, float* best_score, int* best_cls)
+{
+    const int a = blockIdx.x * blockDim.x + threadIdx.x;
+    if (a >= A) {
+        return;
+    }
+    const float* s    = data + static_cast<size_t>(a) * C + 4;
+    float        best = s[0];
+    int          bi   = 0;
+    for (int c = 1; c < nc; ++c) {
+        if (s[c] > best) {
+            best = s[c];
+            bi   = c;
+        }
+    }
+    best_score[a] = best;
+    best_cls[a]   = bi;
+}
+
+// Parallel rotated-NMS suppression (one thread per score-sorted anchor): mark suppressed
+// iff a higher-scoring same-class box has ProbIoU > iou_thr. flag[r] = 1 means survivor.
+__global__ void obb_suppress_kernel(const float* data,
+                                    int          A,
+                                    int          C,
+                                    int          nc,
+                                    const float* sorted_score,
+                                    const int*   sorted_idx,
+                                    const int*   cls,
+                                    float        score_thr,
+                                    float        iou_thr,
+                                    int*         flag)
+{
+    const int r = blockIdx.x * blockDim.x + threadIdx.x;
+    if (r >= A) {
+        return;
+    }
+    if (sorted_score[r] <= score_thr) {
+        flag[r] = 0;
+        return;
+    }
+    const int    a      = sorted_idx[r];
+    const float* row    = data + static_cast<size_t>(a) * C;
+    const float  box[4] = {row[0], row[1], row[2], row[3]};
+    const float  ang    = row[4 + nc];
+    const int    cl     = cls[a];
+    for (int p = 0; p < r; ++p) {
+        const int ap = sorted_idx[p];
+        if (cls[ap] == cl) {
+            const float* rp    = data + static_cast<size_t>(ap) * C;
+            const float  bp[4] = {rp[0], rp[1], rp[2], rp[3]};
+            if (iou_probiou(box, ang, bp, rp[4 + nc]) > iou_thr) {
+                flag[r] = 0;
+                return;
+            }
+        }
+    }
+    flag[r] = 1;
+}
+
+// Compaction (single thread): gather survivors in score order, copying center box + angle.
+__global__ void obb_compact_kernel(const float* data,
+                                   int          A,
+                                   int          C,
+                                   int          nc,
+                                   const float* sorted_score,
+                                   const int*   sorted_idx,
+                                   const int*   cls,
+                                   const int*   flag,
+                                   float        score_thr,
+                                   int          topk,
+                                   int*         num_dets,
+                                   float*       out_boxes,
+                                   float*       out_scores,
+                                   int*         out_classes,
+                                   float*       out_angles)
+{
+    int keep = 0;
+    for (int r = 0; r < A && keep < topk; ++r) {
+        if (sorted_score[r] <= score_thr) {
+            break;
+        }
+        if (!flag[r]) {
+            continue;
+        }
+        const int    a          = sorted_idx[r];
+        const float* row        = data + static_cast<size_t>(a) * C;
+        out_boxes[keep * 4 + 0] = row[0];
+        out_boxes[keep * 4 + 1] = row[1];
+        out_boxes[keep * 4 + 2] = row[2];
+        out_boxes[keep * 4 + 3] = row[3];
+        out_scores[keep]        = sorted_score[r];
+        out_classes[keep]       = cls[a];
+        out_angles[keep]        = row[4 + nc];
+        ++keep;
+    }
+    *num_dets = keep;
+}
+
+// ---- plugin ----------------------------------------------------------------
+
+class YoloObbPostprocess: public nvinfer1::IPluginV2DynamicExt {
+public:
+    explicit YoloObbPostprocess(ObbParams p): params_(p) {}
+    YoloObbPostprocess(const void* data, size_t length)
+    {
+        std::memcpy(&params_, data, sizeof(ObbParams));
+        (void)length;
+    }
+    YoloObbPostprocess(const YoloObbPostprocess&) = default;
+
+    nvinfer1::IPluginV2DynamicExt* clone() const noexcept override
+    {
+        auto* q = new YoloObbPostprocess(*this);
+        q->setPluginNamespace(namespace_.c_str());
+        return q;
+    }
+
+    nvinfer1::DimsExprs getOutputDimensions(int32_t                    outputIndex,
+                                            const nvinfer1::DimsExprs* inputs,
+                                            int32_t                    nbInputs,
+                                            nvinfer1::IExprBuilder&    expr) noexcept override
+    {
+        (void)nbInputs;
+        nvinfer1::DimsExprs out;
+        const auto*         batch = inputs[0].d[0];
+        const auto*         topk  = expr.constant(params_.max_output);
+        if (outputIndex == 0) {  // num_dets [B, 1]
+            out.nbDims = 2;
+            out.d[0]   = batch;
+            out.d[1]   = expr.constant(1);
+        }
+        else if (outputIndex == 1) {  // boxes [B, topk, 4] (cx,cy,w,h)
+            out.nbDims = 3;
+            out.d[0]   = batch;
+            out.d[1]   = topk;
+            out.d[2]   = expr.constant(4);
+        }
+        else if (outputIndex == 4) {  // angles [B, topk, 1]
+            out.nbDims = 3;
+            out.d[0]   = batch;
+            out.d[1]   = topk;
+            out.d[2]   = expr.constant(1);
+        }
+        else {  // scores [B, topk] / classes [B, topk]
+            out.nbDims = 2;
+            out.d[0]   = batch;
+            out.d[1]   = topk;
+        }
+        return out;
+    }
+
+    bool supportsFormatCombination(int32_t                           pos,
+                                   const nvinfer1::PluginTensorDesc* inOut,
+                                   int32_t                           nbInputs,
+                                   int32_t                           nbOutputs) noexcept override
+    {
+        (void)nbInputs;
+        (void)nbOutputs;
+        const auto& d = inOut[pos];
+        if (d.format != nvinfer1::TensorFormat::kLINEAR) {
+            return false;
+        }
+        // 1 float input (pos 0); outputs: 1 num_dets(int32), 2 boxes, 3 scores, 4 classes(int32), 5 angles.
+        if (pos == 1 || pos == 4) {
+            return d.type == nvinfer1::DataType::kINT32;
+        }
+        return d.type == nvinfer1::DataType::kFLOAT;
+    }
+
+    void configurePlugin(const nvinfer1::DynamicPluginTensorDesc*,
+                         int32_t,
+                         const nvinfer1::DynamicPluginTensorDesc*,
+                         int32_t) noexcept override
+    {
+    }
+
+    size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
+                            int32_t                           nbInputs,
+                            const nvinfer1::PluginTensorDesc*,
+                            int32_t) const noexcept override
+    {
+        (void)nbInputs;
+        return nms_workspace_bytes(inputs[0].dims.d[1]);
+    }
+
+    int32_t enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
+                    const nvinfer1::PluginTensorDesc*,
+                    const void* const* inputs,
+                    void* const*       outputs,
+                    void*              workspace,
+                    cudaStream_t       stream) noexcept override
+    {
+        const int B  = inputDesc[0].dims.d[0];
+        const int A  = inputDesc[0].dims.d[1];
+        const int C  = inputDesc[0].dims.d[2];
+        const int nc = C - 5;  // 4 box + nc + 1 angle
+
+        int* num_dets = static_cast<int*>(outputs[0]);
+        if (nc < 1) {
+            cudaMemsetAsync(num_dets, 0, static_cast<size_t>(B) * sizeof(int), stream);
+            return 0;
+        }
+
+        const float* data        = static_cast<const float*>(inputs[0]);
+        float*       out_boxes   = static_cast<float*>(outputs[1]);
+        float*       out_scores  = static_cast<float*>(outputs[2]);
+        int*         out_classes = static_cast<int*>(outputs[3]);
+        float*       out_angles  = static_cast<float*>(outputs[4]);
+
+        char*  ws       = static_cast<char*>(workspace);
+        float* keys_in  = reinterpret_cast<float*>(ws);
+        float* keys_out = keys_in + A;
+        int*   idx_in   = reinterpret_cast<int*>(keys_out + A);
+        int*   idx_out  = idx_in + A;
+        int*   cls_buf  = idx_out + A;
+        int*   flag     = cls_buf + A;
+
+        const int t  = params_.max_output;
+        const int bk = 256;
+        const int gd = (A + bk - 1) / bk;
+        for (int b = 0; b < B; ++b) {
+            const float* d = data + static_cast<size_t>(b) * A * C;
+            obb_argmax_kernel<<<gd, bk, 0, stream>>>(d, A, C, nc, keys_in, cls_buf);
+            iota_kernel<<<gd, bk, 0, stream>>>(idx_in, A);
+            sort_scores_desc(workspace, A, keys_in, keys_out, idx_in, idx_out, stream);
+            obb_suppress_kernel<<<gd, bk, 0, stream>>>(
+                d, A, C, nc, keys_out, idx_out, cls_buf, params_.score_threshold, params_.iou_threshold, flag);
+            obb_compact_kernel<<<1, 1, 0, stream>>>(d,
+                                                    A,
+                                                    C,
+                                                    nc,
+                                                    keys_out,
+                                                    idx_out,
+                                                    cls_buf,
+                                                    flag,
+                                                    params_.score_threshold,
+                                                    t,
+                                                    num_dets + b,
+                                                    out_boxes + static_cast<size_t>(b) * t * 4,
+                                                    out_scores + static_cast<size_t>(b) * t,
+                                                    out_classes + static_cast<size_t>(b) * t,
+                                                    out_angles + static_cast<size_t>(b) * t);
+        }
+        return cudaGetLastError() == cudaSuccess ? 0 : -1;
+    }
+
+    nvinfer1::DataType getOutputDataType(int32_t index, const nvinfer1::DataType*, int32_t) const noexcept override
+    {
+        return (index == 0 || index == 3) ? nvinfer1::DataType::kINT32 : nvinfer1::DataType::kFLOAT;
+    }
+
+    const char* getPluginType() const noexcept override
+    {
+        return kPluginName;
+    }
+    const char* getPluginVersion() const noexcept override
+    {
+        return kPluginVersion;
+    }
+    int32_t getNbOutputs() const noexcept override
+    {
+        return 5;
+    }
+    int32_t initialize() noexcept override
+    {
+        return 0;
+    }
+    void   terminate() noexcept override {}
+    size_t getSerializationSize() const noexcept override
+    {
+        return sizeof(ObbParams);
+    }
+    void serialize(void* buffer) const noexcept override
+    {
+        std::memcpy(buffer, &params_, sizeof(ObbParams));
+    }
+    void destroy() noexcept override
+    {
+        delete this;
+    }
+    void setPluginNamespace(const char* ns) noexcept override
+    {
+        namespace_ = ns ? ns : "";
+    }
+    const char* getPluginNamespace() const noexcept override
+    {
+        return namespace_.c_str();
+    }
+
+private:
+    ObbParams   params_;
+    std::string namespace_;
+};
+
+class YoloObbPostprocessCreator: public nvinfer1::IPluginCreator {
+public:
+    YoloObbPostprocessCreator()
+    {
+        fields_ = {
+            {"score_threshold", nullptr, nvinfer1::PluginFieldType::kFLOAT32, 1},
+            {"iou_threshold", nullptr, nvinfer1::PluginFieldType::kFLOAT32, 1},
+            {"max_output_boxes", nullptr, nvinfer1::PluginFieldType::kINT32, 1},
+            {"background_class", nullptr, nvinfer1::PluginFieldType::kINT32, 1},
+            {"box_coding", nullptr, nvinfer1::PluginFieldType::kINT32, 1},
+            {"score_activation", nullptr, nvinfer1::PluginFieldType::kINT32, 1},
+        };
+        fc_.nbFields = static_cast<int>(fields_.size());
+        fc_.fields   = fields_.data();
+    }
+
+    const char* getPluginName() const noexcept override
+    {
+        return kPluginName;
+    }
+    const char* getPluginVersion() const noexcept override
+    {
+        return kPluginVersion;
+    }
+    const nvinfer1::PluginFieldCollection* getFieldNames() noexcept override
+    {
+        return &fc_;
+    }
+
+    nvinfer1::IPluginV2* createPlugin(const char*, const nvinfer1::PluginFieldCollection* fc) noexcept override
+    {
+        ObbParams p;
+        for (int i = 0; i < fc->nbFields; ++i) {
+            const auto&       f    = fc->fields[i];
+            const std::string name = f.name;
+            if (name == "score_threshold") {
+                p.score_threshold = *static_cast<const float*>(f.data);
+            }
+            else if (name == "iou_threshold") {
+                p.iou_threshold = *static_cast<const float*>(f.data);
+            }
+            else if (name == "max_output_boxes") {
+                p.max_output = *static_cast<const int*>(f.data);
+            }
+            else if (name == "background_class") {
+                p.background = *static_cast<const int*>(f.data);
+            }
+            else if (name == "box_coding") {
+                p.box_coding = *static_cast<const int*>(f.data);
+            }
+            else if (name == "score_activation") {
+                p.score_activation = *static_cast<const int*>(f.data);
+            }
+        }
+        auto* plugin = new YoloObbPostprocess(p);
+        plugin->setPluginNamespace(namespace_.c_str());
+        return plugin;
+    }
+
+    nvinfer1::IPluginV2* deserializePlugin(const char*, const void* data, size_t length) noexcept override
+    {
+        auto* plugin = new YoloObbPostprocess(data, length);
+        plugin->setPluginNamespace(namespace_.c_str());
+        return plugin;
+    }
+
+    void setPluginNamespace(const char* ns) noexcept override
+    {
+        namespace_ = ns ? ns : "";
+    }
+    const char* getPluginNamespace() const noexcept override
+    {
+        return namespace_.c_str();
+    }
+
+private:
+    std::vector<nvinfer1::PluginField> fields_;
+    nvinfer1::PluginFieldCollection    fc_{};
+    std::string                        namespace_;
+};
+
+}  // namespace
+
+REGISTER_TENSORRT_PLUGIN(YoloObbPostprocessCreator);

--- a/csrc/plugins/src/pose_plugin.cu
+++ b/csrc/plugins/src/pose_plugin.cu
@@ -1,0 +1,420 @@
+// YoloPosePostprocess — pose postprocess plugin. Unlike det/seg (whose graphs decode
+// in-model and feed separate tensors), pose engines come from the raw ultralytics
+// export, so this plugin takes the single transposed head tensor [B, A, C] with
+// C = 4 + nc + 51 (xc,yc,w,h | nc class scores | 17 keypoints x 3) and does argmax +
+// NMS + top-k, gathering each kept box's 51 keypoint values. Boxes are decoded
+// center-xywh; the plugin converts to corner for NMS and emits corner xyxy (like the
+// other plugins). Registered in libyolov8_plugins.so via REGISTER_TENSORRT_PLUGIN.
+
+#include "NvInferPlugin.h"
+#include "nms_common.cuh"
+#include <cstring>
+#include <cuda_runtime.h>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace yolov8_plugin;  // iota_kernel, cub sort helpers, iou_xyxy
+
+const char* kPluginName    = "YoloPosePostprocess";
+const char* kPluginVersion = "1";
+const int   kKpt           = 51;  // 17 keypoints x (x, y, score)
+
+struct PoseParams {
+    float score_threshold  = 0.25f;
+    float iou_threshold    = 0.65f;
+    int   max_output       = 100;
+    int   background       = -1;
+    int   box_coding       = 0;
+    int   score_activation = 0;
+};
+
+// Per-anchor argmax over the class channels of a row-major [A, C] tensor (scores at
+// offset 4, length nc).
+__global__ void pose_argmax_kernel(const float* data, int A, int C, int nc, float* best_score, int* best_cls)
+{
+    const int a = blockIdx.x * blockDim.x + threadIdx.x;
+    if (a >= A) {
+        return;
+    }
+    const float* s    = data + static_cast<size_t>(a) * C + 4;
+    float        best = s[0];
+    int          bi   = 0;
+    for (int c = 1; c < nc; ++c) {
+        if (s[c] > best) {
+            best = s[c];
+            bi   = c;
+        }
+    }
+    best_score[a] = best;
+    best_cls[a]   = bi;
+}
+
+__device__ inline void pose_corner(const float* row, float* box)
+{
+    const float cx = row[0], cy = row[1], w = row[2], h = row[3];
+    box[0] = cx - 0.5f * w;
+    box[1] = cy - 0.5f * h;
+    box[2] = cx + 0.5f * w;
+    box[3] = cy + 0.5f * h;
+}
+
+// Parallel NMS suppression (one thread per score-sorted anchor); decodes center-xywh to
+// corner for axis-aligned IoU. flag[r] = 1 means survivor.
+__global__ void pose_suppress_kernel(const float* data,
+                                     int          A,
+                                     int          C,
+                                     const float* sorted_score,
+                                     const int*   sorted_idx,
+                                     const int*   cls,
+                                     float        score_thr,
+                                     float        iou_thr,
+                                     int*         flag)
+{
+    const int r = blockIdx.x * blockDim.x + threadIdx.x;
+    if (r >= A) {
+        return;
+    }
+    if (sorted_score[r] <= score_thr) {
+        flag[r] = 0;
+        return;
+    }
+    const int a = sorted_idx[r];
+    float     box[4];
+    pose_corner(data + static_cast<size_t>(a) * C, box);
+    const int cl = cls[a];
+    for (int p = 0; p < r; ++p) {
+        const int ap = sorted_idx[p];
+        if (cls[ap] == cl) {
+            float bp[4];
+            pose_corner(data + static_cast<size_t>(ap) * C, bp);
+            if (iou_xyxy(box, bp) > iou_thr) {
+                flag[r] = 0;
+                return;
+            }
+        }
+    }
+    flag[r] = 1;
+}
+
+// Compaction (single thread): gather survivors in score order, copying box + 51 kpts.
+__global__ void pose_compact_kernel(const float* data,
+                                    int          A,
+                                    int          C,
+                                    int          nc,
+                                    const float* sorted_score,
+                                    const int*   sorted_idx,
+                                    const int*   cls,
+                                    const int*   flag,
+                                    float        score_thr,
+                                    int          topk,
+                                    int*         num_dets,
+                                    float*       out_boxes,
+                                    float*       out_scores,
+                                    int*         out_classes,
+                                    float*       out_kpts)
+{
+    int keep = 0;
+    for (int r = 0; r < A && keep < topk; ++r) {
+        if (sorted_score[r] <= score_thr) {
+            break;
+        }
+        if (!flag[r]) {
+            continue;
+        }
+        const int    a   = sorted_idx[r];
+        const float* row = data + static_cast<size_t>(a) * C;
+        pose_corner(row, out_boxes + keep * 4);
+        out_scores[keep]  = sorted_score[r];
+        out_classes[keep] = cls[a];
+        const float* kp   = row + 4 + nc;
+        float*       dst  = out_kpts + static_cast<size_t>(keep) * kKpt;
+        for (int j = 0; j < kKpt; ++j) {
+            dst[j] = kp[j];
+        }
+        ++keep;
+    }
+    *num_dets = keep;
+}
+
+class YoloPosePostprocess: public nvinfer1::IPluginV2DynamicExt {
+public:
+    explicit YoloPosePostprocess(PoseParams p): params_(p) {}
+    YoloPosePostprocess(const void* data, size_t length)
+    {
+        std::memcpy(&params_, data, sizeof(PoseParams));
+        (void)length;
+    }
+    YoloPosePostprocess(const YoloPosePostprocess&) = default;
+
+    nvinfer1::IPluginV2DynamicExt* clone() const noexcept override
+    {
+        auto* q = new YoloPosePostprocess(*this);
+        q->setPluginNamespace(namespace_.c_str());
+        return q;
+    }
+
+    nvinfer1::DimsExprs getOutputDimensions(int32_t                    outputIndex,
+                                            const nvinfer1::DimsExprs* inputs,
+                                            int32_t                    nbInputs,
+                                            nvinfer1::IExprBuilder&    expr) noexcept override
+    {
+        (void)nbInputs;
+        nvinfer1::DimsExprs out;
+        const auto*         batch = inputs[0].d[0];
+        const auto*         topk  = expr.constant(params_.max_output);
+        if (outputIndex == 0) {  // num_dets [B, 1]
+            out.nbDims = 2;
+            out.d[0]   = batch;
+            out.d[1]   = expr.constant(1);
+        }
+        else if (outputIndex == 1) {  // boxes [B, topk, 4]
+            out.nbDims = 3;
+            out.d[0]   = batch;
+            out.d[1]   = topk;
+            out.d[2]   = expr.constant(4);
+        }
+        else if (outputIndex == 4) {  // kpts [B, topk, 51]
+            out.nbDims = 3;
+            out.d[0]   = batch;
+            out.d[1]   = topk;
+            out.d[2]   = expr.constant(kKpt);
+        }
+        else {  // scores [B, topk] / classes [B, topk]
+            out.nbDims = 2;
+            out.d[0]   = batch;
+            out.d[1]   = topk;
+        }
+        return out;
+    }
+
+    bool supportsFormatCombination(int32_t                           pos,
+                                   const nvinfer1::PluginTensorDesc* inOut,
+                                   int32_t                           nbInputs,
+                                   int32_t                           nbOutputs) noexcept override
+    {
+        (void)nbInputs;
+        (void)nbOutputs;
+        const auto& d = inOut[pos];
+        if (d.format != nvinfer1::TensorFormat::kLINEAR) {
+            return false;
+        }
+        // 1 float input (pos 0); outputs: 1 num_dets(int32), 2 boxes, 3 scores, 4 classes(int32), 5 kpts.
+        if (pos == 1 || pos == 4) {
+            return d.type == nvinfer1::DataType::kINT32;
+        }
+        return d.type == nvinfer1::DataType::kFLOAT;
+    }
+
+    void configurePlugin(const nvinfer1::DynamicPluginTensorDesc*,
+                         int32_t,
+                         const nvinfer1::DynamicPluginTensorDesc*,
+                         int32_t) noexcept override
+    {
+    }
+
+    size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
+                            int32_t                           nbInputs,
+                            const nvinfer1::PluginTensorDesc*,
+                            int32_t) const noexcept override
+    {
+        (void)nbInputs;
+        return nms_workspace_bytes(inputs[0].dims.d[1]);
+    }
+
+    int32_t enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
+                    const nvinfer1::PluginTensorDesc*,
+                    const void* const* inputs,
+                    void* const*       outputs,
+                    void*              workspace,
+                    cudaStream_t       stream) noexcept override
+    {
+        const int B  = inputDesc[0].dims.d[0];
+        const int A  = inputDesc[0].dims.d[1];
+        const int C  = inputDesc[0].dims.d[2];
+        const int nc = C - 4 - kKpt;
+
+        int* num_dets = static_cast<int*>(outputs[0]);
+        if (nc < 1) {
+            // Malformed head (not a 17-keypoint pose model): emit zero detections
+            // rather than risk an out-of-bounds keypoint gather.
+            cudaMemsetAsync(num_dets, 0, static_cast<size_t>(B) * sizeof(int), stream);
+            return 0;
+        }
+
+        const float* data        = static_cast<const float*>(inputs[0]);
+        float*       out_boxes   = static_cast<float*>(outputs[1]);
+        float*       out_scores  = static_cast<float*>(outputs[2]);
+        int*         out_classes = static_cast<int*>(outputs[3]);
+        float*       out_kpts    = static_cast<float*>(outputs[4]);
+
+        char*  ws       = static_cast<char*>(workspace);
+        float* keys_in  = reinterpret_cast<float*>(ws);
+        float* keys_out = keys_in + A;
+        int*   idx_in   = reinterpret_cast<int*>(keys_out + A);
+        int*   idx_out  = idx_in + A;
+        int*   cls_buf  = idx_out + A;
+        int*   flag     = cls_buf + A;
+
+        const int t  = params_.max_output;
+        const int bk = 256;
+        const int gd = (A + bk - 1) / bk;
+        for (int b = 0; b < B; ++b) {
+            const float* d = data + static_cast<size_t>(b) * A * C;
+            pose_argmax_kernel<<<gd, bk, 0, stream>>>(d, A, C, nc, keys_in, cls_buf);
+            iota_kernel<<<gd, bk, 0, stream>>>(idx_in, A);
+            sort_scores_desc(workspace, A, keys_in, keys_out, idx_in, idx_out, stream);
+            pose_suppress_kernel<<<gd, bk, 0, stream>>>(
+                d, A, C, keys_out, idx_out, cls_buf, params_.score_threshold, params_.iou_threshold, flag);
+            pose_compact_kernel<<<1, 1, 0, stream>>>(d,
+                                                     A,
+                                                     C,
+                                                     nc,
+                                                     keys_out,
+                                                     idx_out,
+                                                     cls_buf,
+                                                     flag,
+                                                     params_.score_threshold,
+                                                     t,
+                                                     num_dets + b,
+                                                     out_boxes + static_cast<size_t>(b) * t * 4,
+                                                     out_scores + static_cast<size_t>(b) * t,
+                                                     out_classes + static_cast<size_t>(b) * t,
+                                                     out_kpts + static_cast<size_t>(b) * t * kKpt);
+        }
+        return cudaGetLastError() == cudaSuccess ? 0 : -1;
+    }
+
+    nvinfer1::DataType getOutputDataType(int32_t index, const nvinfer1::DataType*, int32_t) const noexcept override
+    {
+        return (index == 0 || index == 3) ? nvinfer1::DataType::kINT32 : nvinfer1::DataType::kFLOAT;
+    }
+
+    const char* getPluginType() const noexcept override
+    {
+        return kPluginName;
+    }
+    const char* getPluginVersion() const noexcept override
+    {
+        return kPluginVersion;
+    }
+    int32_t getNbOutputs() const noexcept override
+    {
+        return 5;
+    }
+    int32_t initialize() noexcept override
+    {
+        return 0;
+    }
+    void   terminate() noexcept override {}
+    size_t getSerializationSize() const noexcept override
+    {
+        return sizeof(PoseParams);
+    }
+    void serialize(void* buffer) const noexcept override
+    {
+        std::memcpy(buffer, &params_, sizeof(PoseParams));
+    }
+    void destroy() noexcept override
+    {
+        delete this;
+    }
+    void setPluginNamespace(const char* ns) noexcept override
+    {
+        namespace_ = ns ? ns : "";
+    }
+    const char* getPluginNamespace() const noexcept override
+    {
+        return namespace_.c_str();
+    }
+
+private:
+    PoseParams  params_;
+    std::string namespace_;
+};
+
+class YoloPosePostprocessCreator: public nvinfer1::IPluginCreator {
+public:
+    YoloPosePostprocessCreator()
+    {
+        fields_ = {
+            {"score_threshold", nullptr, nvinfer1::PluginFieldType::kFLOAT32, 1},
+            {"iou_threshold", nullptr, nvinfer1::PluginFieldType::kFLOAT32, 1},
+            {"max_output_boxes", nullptr, nvinfer1::PluginFieldType::kINT32, 1},
+            {"background_class", nullptr, nvinfer1::PluginFieldType::kINT32, 1},
+            {"box_coding", nullptr, nvinfer1::PluginFieldType::kINT32, 1},
+            {"score_activation", nullptr, nvinfer1::PluginFieldType::kINT32, 1},
+        };
+        fc_.nbFields = static_cast<int>(fields_.size());
+        fc_.fields   = fields_.data();
+    }
+
+    const char* getPluginName() const noexcept override
+    {
+        return kPluginName;
+    }
+    const char* getPluginVersion() const noexcept override
+    {
+        return kPluginVersion;
+    }
+    const nvinfer1::PluginFieldCollection* getFieldNames() noexcept override
+    {
+        return &fc_;
+    }
+
+    nvinfer1::IPluginV2* createPlugin(const char*, const nvinfer1::PluginFieldCollection* fc) noexcept override
+    {
+        PoseParams p;
+        for (int i = 0; i < fc->nbFields; ++i) {
+            const auto&       f    = fc->fields[i];
+            const std::string name = f.name;
+            if (name == "score_threshold") {
+                p.score_threshold = *static_cast<const float*>(f.data);
+            }
+            else if (name == "iou_threshold") {
+                p.iou_threshold = *static_cast<const float*>(f.data);
+            }
+            else if (name == "max_output_boxes") {
+                p.max_output = *static_cast<const int*>(f.data);
+            }
+            else if (name == "background_class") {
+                p.background = *static_cast<const int*>(f.data);
+            }
+            else if (name == "box_coding") {
+                p.box_coding = *static_cast<const int*>(f.data);
+            }
+            else if (name == "score_activation") {
+                p.score_activation = *static_cast<const int*>(f.data);
+            }
+        }
+        auto* plugin = new YoloPosePostprocess(p);
+        plugin->setPluginNamespace(namespace_.c_str());
+        return plugin;
+    }
+
+    nvinfer1::IPluginV2* deserializePlugin(const char*, const void* data, size_t length) noexcept override
+    {
+        auto* plugin = new YoloPosePostprocess(data, length);
+        plugin->setPluginNamespace(namespace_.c_str());
+        return plugin;
+    }
+
+    void setPluginNamespace(const char* ns) noexcept override
+    {
+        namespace_ = ns ? ns : "";
+    }
+    const char* getPluginNamespace() const noexcept override
+    {
+        return namespace_.c_str();
+    }
+
+private:
+    std::vector<nvinfer1::PluginField> fields_;
+    nvinfer1::PluginFieldCollection    fc_{};
+    std::string                        namespace_;
+};
+
+}  // namespace
+
+REGISTER_TENSORRT_PLUGIN(YoloPosePostprocessCreator);

--- a/csrc/plugins/src/seg_plugin.cu
+++ b/csrc/plugins/src/seg_plugin.cu
@@ -1,10 +1,8 @@
-// YoloDetPostprocess — a TensorRT plugin that fuses YOLOv8 detection
-// score-threshold + NMS + top-k on the GPU. It consumes the already-decoded head
-// outputs (corner boxes + per-class scores, exactly what models/common.py PostDetect
-// feeds EfficientNMS_TRT) and emits the same four tensors as EfficientNMS_TRT, so it
-// is a drop-in alternative. Built into libyolov8_plugins.so and registered via
-// REGISTER_TENSORRT_PLUGIN. Implemented against IPluginV2DynamicExt, whose API is
-// stable across TensorRT 8 / 10 / 11 (deprecated on 10+ but functional).
+// YoloSegPostprocess — segmentation postprocess plugin. Same decode+NMS+top-k as
+// YoloDetPostprocess, but it takes a third input (per-anchor mask coefficients) and
+// emits a fifth output: the coefficients of the kept boxes. Mask assembly (proto
+// matmul + sigmoid + crop + resize) stays outside the engine. Registered in
+// libyolov8_plugins.so via REGISTER_TENSORRT_PLUGIN.
 
 #include "NvInferPlugin.h"
 #include "nms_common.cuh"
@@ -17,33 +15,36 @@ namespace {
 
 using namespace yolov8_plugin;  // iou_xyxy, argmax_kernel, iota_kernel, nms_* helpers
 
-const char* kPluginName    = "YoloDetPostprocess";
+const char* kPluginName    = "YoloSegPostprocess";
 const char* kPluginVersion = "1";
 
-struct DetParams {
+struct SegParams {
     float score_threshold  = 0.25f;
     float iou_threshold    = 0.65f;
     int   max_output       = 100;  // top-k
-    int   background       = -1;   // unused (kept for EfficientNMS attribute parity)
-    int   box_coding       = 0;    // 0 = corner [x1,y1,x2,y2] (the only mode we emit)
-    int   score_activation = 0;    // scores already sigmoided upstream
+    int   background       = -1;
+    int   box_coding       = 0;
+    int   score_activation = 0;
 };
 
 // Parallel NMS suppression is shared (suppress_xyxy_kernel in nms_common.cuh).
-// Part 2 (single thread, no IoU): gather survivors in score order up to
-// top-k. Cheap O(candidates) — the expensive O(M^2) overlap work is done in parallel above.
-__global__ void compact_kernel(const float* boxes,
-                               const float* sorted_score,
-                               const int*   sorted_idx,
-                               const int*   cls,
-                               const int*   flag,
-                               int          num_anchors,
-                               float        score_thr,
-                               int          topk,
-                               int*         num_dets,
-                               float*       out_boxes,
-                               float*       out_scores,
-                               int*         out_classes)
+// Compaction (single thread, no IoU): gather survivors in score order up to top-k,
+// copying each kept box's nm mask coefficients.
+__global__ void seg_compact_kernel(const float* boxes,
+                                   const float* coeffs,
+                                   int          nm,
+                                   const float* sorted_score,
+                                   const int*   sorted_idx,
+                                   const int*   cls,
+                                   const int*   flag,
+                                   int          num_anchors,
+                                   float        score_thr,
+                                   int          topk,
+                                   int*         num_dets,
+                                   float*       out_boxes,
+                                   float*       out_scores,
+                                   int*         out_classes,
+                                   float*       out_coeffs)
 {
     int keep = 0;
     for (int r = 0; r < num_anchors && keep < topk; ++r) {
@@ -61,28 +62,29 @@ __global__ void compact_kernel(const float* boxes,
         out_boxes[keep * 4 + 3] = bx[3];
         out_scores[keep]        = sorted_score[r];
         out_classes[keep]       = cls[a];
+        const float* cf         = coeffs + static_cast<size_t>(a) * nm;
+        float*       dst        = out_coeffs + static_cast<size_t>(keep) * nm;
+        for (int j = 0; j < nm; ++j) {
+            dst[j] = cf[j];
+        }
         ++keep;
     }
     *num_dets = keep;
 }
 
-// ---- plugin ----------------------------------------------------------------
-
-class YoloDetPostprocess: public nvinfer1::IPluginV2DynamicExt {
+class YoloSegPostprocess: public nvinfer1::IPluginV2DynamicExt {
 public:
-    explicit YoloDetPostprocess(DetParams p): params_(p) {}
-    YoloDetPostprocess(const void* data, size_t length)
+    explicit YoloSegPostprocess(SegParams p): params_(p) {}
+    YoloSegPostprocess(const void* data, size_t length)
     {
-        const char* p = static_cast<const char*>(data);
-        std::memcpy(&params_, p, sizeof(DetParams));
+        std::memcpy(&params_, data, sizeof(SegParams));
         (void)length;
     }
-    YoloDetPostprocess(const YoloDetPostprocess&) = default;
+    YoloSegPostprocess(const YoloSegPostprocess&) = default;
 
-    // IPluginV2DynamicExt
     nvinfer1::IPluginV2DynamicExt* clone() const noexcept override
     {
-        auto* q = new YoloDetPostprocess(*this);
+        auto* q = new YoloSegPostprocess(*this);
         q->setPluginNamespace(namespace_.c_str());
         return q;
     }
@@ -107,6 +109,12 @@ public:
             out.d[1]   = topk;
             out.d[2]   = expr.constant(4);
         }
+        else if (outputIndex == 4) {  // mask_coeffs [B, topk, nm]
+            out.nbDims = 3;
+            out.d[0]   = batch;
+            out.d[1]   = topk;
+            out.d[2]   = inputs[2].d[2];
+        }
         else {  // scores [B, topk] / classes [B, topk]
             out.nbDims = 2;
             out.d[0]   = batch;
@@ -126,8 +134,8 @@ public:
         if (d.format != nvinfer1::TensorFormat::kLINEAR) {
             return false;
         }
-        // inputs 0,1 float; outputs: 0 int32 (num_dets), 1 float (boxes), 2 float (scores), 3 int32 (classes)
-        if (pos == 2 || pos == 5) {
+        // 3 float inputs; outputs: 3 num_dets(int32), 4 boxes, 5 scores, 6 classes(int32), 7 coeffs.
+        if (pos == 3 || pos == 6) {
             return d.type == nvinfer1::DataType::kINT32;
         }
         return d.type == nvinfer1::DataType::kFLOAT;
@@ -140,9 +148,6 @@ public:
     {
     }
 
-    // Workspace: 5 int/float arrays of length A (keys in/out, idx in/out, class) plus
-    // cub's radix-sort temp storage. cub with pre-allocated temp is CUDA-graph/stream-
-    // capture safe (no host sync, no implicit allocation) — thrust's sort is not.
     size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                             int32_t                           nbInputs,
                             const nvinfer1::PluginTensorDesc*,
@@ -162,13 +167,16 @@ public:
         const int B  = inputDesc[0].dims.d[0];
         const int A  = inputDesc[1].dims.d[1];
         const int nc = inputDesc[1].dims.d[2];
+        const int nm = inputDesc[2].dims.d[2];
 
         const float* boxes       = static_cast<const float*>(inputs[0]);
         const float* scores      = static_cast<const float*>(inputs[1]);
+        const float* coeffs      = static_cast<const float*>(inputs[2]);
         int*         num_dets    = static_cast<int*>(outputs[0]);
         float*       out_boxes   = static_cast<float*>(outputs[1]);
         float*       out_scores  = static_cast<float*>(outputs[2]);
         int*         out_classes = static_cast<int*>(outputs[3]);
+        float*       out_coeffs  = static_cast<float*>(outputs[4]);
 
         char*  ws       = static_cast<char*>(workspace);
         float* keys_in  = reinterpret_cast<float*>(ws);
@@ -178,40 +186,40 @@ public:
         int*   cls_buf  = idx_out + A;
         int*   flag     = cls_buf + A;
 
-        const int t     = params_.max_output;
-        const int block = 256;
-        const int grid  = (A + block - 1) / block;
+        const int t  = params_.max_output;
+        const int bk = 256;
+        const int gd = (A + bk - 1) / bk;
         for (int b = 0; b < B; ++b) {
             const float* bx = boxes + static_cast<size_t>(b) * A * 4;
-            argmax_kernel<<<grid, block, 0, stream>>>(
-                scores + static_cast<size_t>(b) * A * nc, A, nc, keys_in, cls_buf);
-            iota_kernel<<<grid, block, 0, stream>>>(idx_in, A);
+            argmax_kernel<<<gd, bk, 0, stream>>>(scores + static_cast<size_t>(b) * A * nc, A, nc, keys_in, cls_buf);
+            iota_kernel<<<gd, bk, 0, stream>>>(idx_in, A);
             sort_scores_desc(workspace, A, keys_in, keys_out, idx_in, idx_out, stream);
-            suppress_xyxy_kernel<<<grid, block, 0, stream>>>(
+            suppress_xyxy_kernel<<<gd, bk, 0, stream>>>(
                 bx, keys_out, idx_out, cls_buf, A, params_.score_threshold, params_.iou_threshold, flag);
-            compact_kernel<<<1, 1, 0, stream>>>(bx,
-                                                keys_out,
-                                                idx_out,
-                                                cls_buf,
-                                                flag,
-                                                A,
-                                                params_.score_threshold,
-                                                t,
-                                                num_dets + b,
-                                                out_boxes + static_cast<size_t>(b) * t * 4,
-                                                out_scores + static_cast<size_t>(b) * t,
-                                                out_classes + static_cast<size_t>(b) * t);
+            seg_compact_kernel<<<1, 1, 0, stream>>>(bx,
+                                                    coeffs + static_cast<size_t>(b) * A * nm,
+                                                    nm,
+                                                    keys_out,
+                                                    idx_out,
+                                                    cls_buf,
+                                                    flag,
+                                                    A,
+                                                    params_.score_threshold,
+                                                    t,
+                                                    num_dets + b,
+                                                    out_boxes + static_cast<size_t>(b) * t * 4,
+                                                    out_scores + static_cast<size_t>(b) * t,
+                                                    out_classes + static_cast<size_t>(b) * t,
+                                                    out_coeffs + static_cast<size_t>(b) * t * nm);
         }
         return cudaGetLastError() == cudaSuccess ? 0 : -1;
     }
 
-    // IPluginV2Ext
     nvinfer1::DataType getOutputDataType(int32_t index, const nvinfer1::DataType*, int32_t) const noexcept override
     {
         return (index == 0 || index == 3) ? nvinfer1::DataType::kINT32 : nvinfer1::DataType::kFLOAT;
     }
 
-    // IPluginV2
     const char* getPluginType() const noexcept override
     {
         return kPluginName;
@@ -222,7 +230,7 @@ public:
     }
     int32_t getNbOutputs() const noexcept override
     {
-        return 4;
+        return 5;
     }
     int32_t initialize() noexcept override
     {
@@ -231,11 +239,11 @@ public:
     void   terminate() noexcept override {}
     size_t getSerializationSize() const noexcept override
     {
-        return sizeof(DetParams);
+        return sizeof(SegParams);
     }
     void serialize(void* buffer) const noexcept override
     {
-        std::memcpy(buffer, &params_, sizeof(DetParams));
+        std::memcpy(buffer, &params_, sizeof(SegParams));
     }
     void destroy() noexcept override
     {
@@ -251,13 +259,13 @@ public:
     }
 
 private:
-    DetParams   params_;
+    SegParams   params_;
     std::string namespace_;
 };
 
-class YoloDetPostprocessCreator: public nvinfer1::IPluginCreator {
+class YoloSegPostprocessCreator: public nvinfer1::IPluginCreator {
 public:
-    YoloDetPostprocessCreator()
+    YoloSegPostprocessCreator()
     {
         fields_ = {
             {"score_threshold", nullptr, nvinfer1::PluginFieldType::kFLOAT32, 1},
@@ -286,7 +294,7 @@ public:
 
     nvinfer1::IPluginV2* createPlugin(const char*, const nvinfer1::PluginFieldCollection* fc) noexcept override
     {
-        DetParams p;
+        SegParams p;
         for (int i = 0; i < fc->nbFields; ++i) {
             const auto&       f    = fc->fields[i];
             const std::string name = f.name;
@@ -309,14 +317,14 @@ public:
                 p.score_activation = *static_cast<const int*>(f.data);
             }
         }
-        auto* plugin = new YoloDetPostprocess(p);
+        auto* plugin = new YoloSegPostprocess(p);
         plugin->setPluginNamespace(namespace_.c_str());
         return plugin;
     }
 
     nvinfer1::IPluginV2* deserializePlugin(const char*, const void* data, size_t length) noexcept override
     {
-        auto* plugin = new YoloDetPostprocess(data, length);
+        auto* plugin = new YoloSegPostprocess(data, length);
         plugin->setPluginNamespace(namespace_.c_str());
         return plugin;
     }
@@ -338,4 +346,4 @@ private:
 
 }  // namespace
 
-REGISTER_TENSORRT_PLUGIN(YoloDetPostprocessCreator);
+REGISTER_TENSORRT_PLUGIN(YoloSegPostprocessCreator);

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -91,10 +91,12 @@ detections match the CPU path within tolerance, not byte-for-byte.
 
 ## Custom postprocess plugins (opt-in)
 
-The detection postprocess (decode + NMS) can run inside the engine as a custom
-TensorRT plugin (`YoloDetPostprocess`, an alternative to the built-in
-`EfficientNMS_TRT`). Build the plugin library — like the engine, it is tied to the
-TensorRT version it is built against, so use the same `-DTensorRT_ROOT`:
+The postprocess (decode + NMS) can run inside the engine as a custom TensorRT plugin
+instead of on the host: `YoloDetPostprocess` (detection, an alternative to the built-in
+`EfficientNMS_TRT`) and `YoloSegPostprocess` (segmentation — also gathers each kept
+box's mask coefficients; proto matmul + mask assembly still run outside the engine).
+Build the plugin library — like the engine, it is tied to the TensorRT version it is
+built against, so use the same `-DTensorRT_ROOT`:
 
 ```shell
 cmake -S . -B build -DTensorRT_ROOT=/data/TensorRT-10.16.1.11 -DBUILD_PLUGINS=ON
@@ -114,8 +116,15 @@ export YOLOV8_PLUGIN_LIB=$PWD/build/bin/libyolov8_plugins.so   # so build.py / i
 ```
 
 The C++ runtime loads the `.so` from `--plugin-lib` or `$YOLOV8_PLUGIN_LIB` before
-deserializing. The plugin uses cub (not thrust) for its NMS sort, so it is safe under
-CUDA-graph capture. `EfficientNMS_TRT` remains the default; the plugin is opt-in.
+deserializing, and the C++ binaries auto-detect the plugin outputs. The plugins use cub
+(not thrust) for their NMS sort, so they are safe under CUDA-graph capture.
+`EfficientNMS_TRT` / the raw path remain the default; the plugins are opt-in.
+
+> The detection plugin engine also runs under Python (`infer.py --task det`), since its
+> outputs match `EfficientNMS_TRT`. The **segmentation** plugin engine (6 outputs) is
+> currently consumed by the C++ `yolov8_seg` binary only; `infer.py --task seg` still
+> expects the raw two-output engine. Build/export from Python, run seg-plugin inference
+> from C++.
 
 ## Tests
 

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -93,10 +93,13 @@ detections match the CPU path within tolerance, not byte-for-byte.
 
 The postprocess (decode + NMS) can run inside the engine as a custom TensorRT plugin
 instead of on the host: `YoloDetPostprocess` (detection, an alternative to the built-in
-`EfficientNMS_TRT`) and `YoloSegPostprocess` (segmentation — also gathers each kept
-box's mask coefficients; proto matmul + mask assembly still run outside the engine).
-Build the plugin library — like the engine, it is tied to the TensorRT version it is
-built against, so use the same `-DTensorRT_ROOT`:
+`EfficientNMS_TRT`), `YoloSegPostprocess` (segmentation — also gathers each kept box's
+mask coefficients; proto matmul + mask assembly still run outside) and
+`YoloPosePostprocess` (pose — also gathers each kept box's 17 keypoints). det/seg attach
+the plugin via the export scripts' in-graph head; pose uses the raw ultralytics export
+plus `onnx_graphsurgeon` (`export-pose.py`) to append the plugin node. Build the plugin
+library — like the engine, it is tied to the TensorRT version it is built against, so use
+the same `-DTensorRT_ROOT`:
 
 ```shell
 cmake -S . -B build -DTensorRT_ROOT=/data/TensorRT-10.16.1.11 -DBUILD_PLUGINS=ON

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -89,6 +89,34 @@ unaffected. Set GPU architectures with `-DCMAKE_CUDA_ARCHITECTURES=86` (default
 `75;86;89;90`). The kernel's bilinear resize is not bit-identical to `cv::resize`, so
 detections match the CPU path within tolerance, not byte-for-byte.
 
+## Custom postprocess plugins (opt-in)
+
+The detection postprocess (decode + NMS) can run inside the engine as a custom
+TensorRT plugin (`YoloDetPostprocess`, an alternative to the built-in
+`EfficientNMS_TRT`). Build the plugin library — like the engine, it is tied to the
+TensorRT version it is built against, so use the same `-DTensorRT_ROOT`:
+
+```shell
+cmake -S . -B build -DTensorRT_ROOT=/data/TensorRT-10.16.1.11 -DBUILD_PLUGINS=ON
+cmake --build build -j           # -> build/bin/libyolov8_plugins.so
+```
+
+Export an ONNX that emits the plugin node, build an engine with the `.so` loaded,
+then run — the C++ binary auto-detects the plugin/End2End outputs:
+
+```shell
+python export-det.py --weights yolov8s.pt --plugin --input-shape 1 3 640 640
+# build with the plugin registered (trtexec --staticPlugins, or build.py with the env var):
+trtexec --onnx=$PWD/yolov8s.onnx --saveEngine=$PWD/yolov8s.engine --fp16 \
+    --staticPlugins=$PWD/build/bin/libyolov8_plugins.so
+export YOLOV8_PLUGIN_LIB=$PWD/build/bin/libyolov8_plugins.so   # so build.py / infer.py / the C++ runtime can load it
+./build/bin/yolov8_detect yolov8s.engine data/bus.jpg          # or pass --plugin-lib <path>
+```
+
+The C++ runtime loads the `.so` from `--plugin-lib` or `$YOLOV8_PLUGIN_LIB` before
+deserializing. The plugin uses cub (not thrust) for its NMS sort, so it is safe under
+CUDA-graph capture. `EfficientNMS_TRT` remains the default; the plugin is opt-in.
+
 ## Tests
 
 ```shell

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -77,6 +77,18 @@ cmake -S . -B build -DTensorRT_ROOT=/path/to/TensorRT -DCMAKE_CXX_STANDARD=14
 cmake --build build -j
 ```
 
+## GPU preprocessing (opt-in)
+
+By default preprocessing (letterbox + BGR→RGB + normalize) runs on the CPU via OpenCV.
+Passing `--gpu-preprocess` at runtime instead uploads the raw uint8 image and does the
+whole transform in a CUDA kernel, writing the network input directly — no CPU/OpenCV step.
+
+It is compiled only when CMake finds a CUDA compiler (the configure log prints
+`GPU preprocessing: enabled`); otherwise `--gpu-preprocess` throws and the CPU path is
+unaffected. Set GPU architectures with `-DCMAKE_CUDA_ARCHITECTURES=86` (default
+`75;86;89;90`). The kernel's bilinear resize is not bit-identical to `cv::resize`, so
+detections match the CPU path within tolerance, not byte-for-byte.
+
 ## Tests
 
 ```shell

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -95,11 +95,12 @@ The postprocess (decode + NMS) can run inside the engine as a custom TensorRT pl
 instead of on the host: `YoloDetPostprocess` (detection, an alternative to the built-in
 `EfficientNMS_TRT`), `YoloSegPostprocess` (segmentation — also gathers each kept box's
 mask coefficients; proto matmul + mask assembly still run outside) and
-`YoloPosePostprocess` (pose — also gathers each kept box's 17 keypoints). det/seg attach
-the plugin via the export scripts' in-graph head; pose uses the raw ultralytics export
-plus `onnx_graphsurgeon` (`export-pose.py`) to append the plugin node. Build the plugin
-library — like the engine, it is tied to the TensorRT version it is built against, so use
-the same `-DTensorRT_ROOT`:
+`YoloPosePostprocess` (pose — also gathers each kept box's 17 keypoints) and
+`YoloObbPostprocess` (oriented boxes — **rotated** NMS on the GPU, gathers each kept
+box's angle). det/seg attach the plugin via the export scripts' in-graph head; pose and
+obb use the raw ultralytics export plus `onnx_graphsurgeon` (`export-pose.py` /
+`export-obb.py`) to append the plugin node. Build the plugin library — like the engine,
+it is tied to the TensorRT version it is built against, so use the same `-DTensorRT_ROOT`:
 
 ```shell
 cmake -S . -B build -DTensorRT_ROOT=/data/TensorRT-10.16.1.11 -DBUILD_PLUGINS=ON

--- a/export-det.py
+++ b/export-det.py
@@ -25,12 +25,16 @@ def parse_args() -> argparse.Namespace:
         "--input-shape", nargs="+", type=int, default=[1, 3, 640, 640], help="Model input shape only for api builder"
     )
     parser.add_argument("--device", type=str, default="cpu", help="Export ONNX device")
+    parser.add_argument(
+        "--plugin", action="store_true", help="Emit the custom YoloDetPostprocess plugin instead of EfficientNMS_TRT"
+    )
     args = parser.parse_args()
     if len(args.input_shape) != 4:
         raise ValueError(f"--input-shape needs 4 values, got {len(args.input_shape)}")
     PostDetect.conf_thres = args.conf_thres
     PostDetect.iou_thres = args.iou_thres
     PostDetect.topk = args.topk
+    PostDetect.plugin = args.plugin
     return args
 
 

--- a/export-obb.py
+++ b/export-obb.py
@@ -1,0 +1,71 @@
+"""Export a YOLOv8-obb ONNX with the YoloObbPostprocess plugin node appended.
+
+Like export-pose.py: the raw ultralytics obb output [1, C, A] (C = 4 + nc + 1: xc,yc,w,h
+| nc scores | angle) is transposed to [1, A, C] and fed to the plugin via
+onnx_graphsurgeon. The plugin does decode + rotated NMS + top-k and emits the kept
+center boxes + angles. Build with libyolov8_plugins.so loaded.
+"""
+
+import argparse
+
+import numpy as np
+import onnx
+import onnx_graphsurgeon as gs
+from ultralytics import YOLO
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-w", "--weights", type=str, required=True, help="PyTorch yolov8-obb weights")
+    parser.add_argument("--opset", type=int, default=11, help="ONNX opset version")
+    parser.add_argument("--iou-thres", type=float, default=0.65, help="NMS IoU threshold")
+    parser.add_argument("--conf-thres", type=float, default=0.25, help="Score threshold")
+    parser.add_argument("--topk", type=int, default=100, help="Max detections")
+    parser.add_argument("--imgsz", type=int, default=1024, help="Square input size")
+    return parser.parse_args()
+
+
+def main(args: argparse.Namespace) -> None:
+    onnx_path = YOLO(args.weights).export(format="onnx", opset=args.opset, simplify=True, imgsz=args.imgsz)
+
+    graph = gs.import_onnx(onnx.load(onnx_path))
+    raw = graph.outputs[0]  # [1, C, A] = (4 + nc + 1, anchors)
+    c, a = int(raw.shape[1]), int(raw.shape[2])
+
+    transposed = gs.Variable("obb_in", dtype=np.float32, shape=[1, a, c])
+    graph.nodes.append(gs.Node("Transpose", attrs={"perm": [0, 2, 1]}, inputs=[raw], outputs=[transposed]))
+
+    topk = args.topk
+    num_dets = gs.Variable("num_dets", np.int32, [1, 1])
+    bboxes = gs.Variable("bboxes", np.float32, [1, topk, 4])
+    scores = gs.Variable("scores", np.float32, [1, topk])
+    labels = gs.Variable("labels", np.int32, [1, topk])
+    angles = gs.Variable("angles", np.float32, [1, topk, 1])
+    node = gs.Node(
+        "YoloObbPostprocess",
+        name="YoloObbPostprocess_0",
+        attrs={
+            "score_threshold": float(args.conf_thres),
+            "iou_threshold": float(args.iou_thres),
+            "max_output_boxes": int(topk),
+            "background_class": -1,
+            "box_coding": 0,
+            "score_activation": 0,
+            "plugin_version": "1",
+        },
+        inputs=[transposed],
+        outputs=[num_dets, bboxes, scores, labels, angles],
+    )
+    node.domain = "TRT"
+    graph.nodes.append(node)
+    graph.outputs = [num_dets, bboxes, scores, labels, angles]
+    graph.cleanup().toposort()
+
+    model = gs.export_onnx(graph)
+    model.opset_import.append(onnx.helper.make_opsetid("TRT", 1))
+    onnx.save(model, onnx_path)
+    print(f"ONNX export success (plugin), saved as {onnx_path}")
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/export-pose.py
+++ b/export-pose.py
@@ -1,0 +1,72 @@
+"""Export a YOLOv8-pose ONNX with the YoloPosePostprocess plugin node appended.
+
+Pose/obb use the raw ultralytics export (no in-graph decode module like det/seg), so
+the plugin node is attached to the already-decoded head output with onnx_graphsurgeon:
+the raw output [1, C, A] is transposed to [1, A, C] and fed to the plugin, which does
+NMS + top-k and gathers each kept box's keypoints. Build the resulting ONNX with
+libyolov8_plugins.so loaded (trtexec --staticPlugins or build.py with YOLOV8_PLUGIN_LIB).
+"""
+
+import argparse
+
+import numpy as np
+import onnx
+import onnx_graphsurgeon as gs
+from ultralytics import YOLO
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-w", "--weights", type=str, required=True, help="PyTorch yolov8-pose weights")
+    parser.add_argument("--opset", type=int, default=11, help="ONNX opset version")
+    parser.add_argument("--iou-thres", type=float, default=0.65, help="NMS IoU threshold")
+    parser.add_argument("--conf-thres", type=float, default=0.25, help="Score threshold")
+    parser.add_argument("--topk", type=int, default=100, help="Max detections")
+    parser.add_argument("--imgsz", type=int, default=640, help="Square input size")
+    return parser.parse_args()
+
+
+def main(args: argparse.Namespace) -> None:
+    onnx_path = YOLO(args.weights).export(format="onnx", opset=args.opset, simplify=True, imgsz=args.imgsz)
+
+    graph = gs.import_onnx(onnx.load(onnx_path))
+    raw = graph.outputs[0]  # [1, C, A] = (4 + nc + 51, anchors)
+    c, a = int(raw.shape[1]), int(raw.shape[2])
+
+    transposed = gs.Variable("pose_in", dtype=np.float32, shape=[1, a, c])
+    graph.nodes.append(gs.Node("Transpose", attrs={"perm": [0, 2, 1]}, inputs=[raw], outputs=[transposed]))
+
+    topk = args.topk
+    num_dets = gs.Variable("num_dets", np.int32, [1, 1])
+    bboxes = gs.Variable("bboxes", np.float32, [1, topk, 4])
+    scores = gs.Variable("scores", np.float32, [1, topk])
+    labels = gs.Variable("labels", np.int32, [1, topk])
+    kpts = gs.Variable("kpts", np.float32, [1, topk, 51])
+    node = gs.Node(
+        "YoloPosePostprocess",
+        name="YoloPosePostprocess_0",
+        attrs={
+            "score_threshold": float(args.conf_thres),
+            "iou_threshold": float(args.iou_thres),
+            "max_output_boxes": int(topk),
+            "background_class": -1,
+            "box_coding": 0,
+            "score_activation": 0,
+            "plugin_version": "1",
+        },
+        inputs=[transposed],
+        outputs=[num_dets, bboxes, scores, labels, kpts],
+    )
+    node.domain = "TRT"
+    graph.nodes.append(node)
+    graph.outputs = [num_dets, bboxes, scores, labels, kpts]
+    graph.cleanup().toposort()
+
+    model = gs.export_onnx(graph)
+    model.opset_import.append(onnx.helper.make_opsetid("TRT", 1))
+    onnx.save(model, onnx_path)
+    print(f"ONNX export success (plugin), saved as {onnx_path}")
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/export-seg.py
+++ b/export-seg.py
@@ -5,7 +5,7 @@ import onnx
 import torch
 from ultralytics import YOLO
 
-from models.common import optim
+from models.common import PostSeg, optim
 
 try:
     import onnxsim
@@ -22,9 +22,19 @@ def parse_args() -> argparse.Namespace:
         "--input-shape", nargs="+", type=int, default=[1, 3, 640, 640], help="Model input shape only for api builder"
     )
     parser.add_argument("--device", type=str, default="cpu", help="Export ONNX device")
+    parser.add_argument(
+        "--plugin", action="store_true", help="Emit the YoloSegPostprocess plugin (decode+NMS+mask coeffs in-engine)"
+    )
+    parser.add_argument("--iou-thres", type=float, default=0.65, help="IoU threshold (plugin)")
+    parser.add_argument("--conf-thres", type=float, default=0.25, help="Score threshold (plugin)")
+    parser.add_argument("--topk", type=int, default=100, help="Max detections (plugin)")
     args = parser.parse_args()
     if len(args.input_shape) != 4:
         raise ValueError(f"--input-shape needs 4 values, got {len(args.input_shape)}")
+    PostSeg.plugin = args.plugin
+    PostSeg.iou_thres = args.iou_thres
+    PostSeg.conf_thres = args.conf_thres
+    PostSeg.topk = args.topk
     return args
 
 
@@ -39,6 +49,9 @@ def main(args: argparse.Namespace) -> None:
     for _ in range(2):
         model(fake_input)
     save_path = args.weights.replace(".pt", ".onnx")
+    output_names = (
+        ["num_dets", "bboxes", "scores", "labels", "mask_coeffs", "proto"] if args.plugin else ["outputs", "proto"]
+    )
     with BytesIO() as f:
         torch.onnx.export(
             model,
@@ -46,7 +59,7 @@ def main(args: argparse.Namespace) -> None:
             f,
             opset_version=args.opset,
             input_names=["images"],
-            output_names=["outputs", "proto"],
+            output_names=output_names,
             dynamo=False,
         )
         f.seek(0)

--- a/models/backend.py
+++ b/models/backend.py
@@ -17,6 +17,7 @@ import tensorrt as trt
 from numpy import ndarray
 
 from models import compat
+from models.plugins import load_plugin_lib
 
 os.environ["CUDA_MODULE_LOADING"] = "LAZY"
 warnings.filterwarnings(action="ignore", category=DeprecationWarning)
@@ -43,6 +44,7 @@ class Backend(ABC):
 
     def __init_engine(self) -> None:
         logger = trt.Logger(trt.Logger.WARNING)
+        load_plugin_lib()  # register custom plugins before deserialize (no-op unless YOLOV8_PLUGIN_LIB set)
         trt.init_libnvinfer_plugins(logger, namespace="")
         with trt.Runtime(logger) as runtime:
             model = runtime.deserialize_cuda_engine(self.weight.read_bytes())

--- a/models/common.py
+++ b/models/common.py
@@ -123,6 +123,64 @@ class TRT_YoloDet(torch.autograd.Function):
         return nums_dets, boxes, scores, classes
 
 
+class TRT_YoloSeg(torch.autograd.Function):
+    """Decode+NMS+top-k for segmentation; also gathers per-box mask coefficients.
+    Targets the YoloSegPostprocess plugin (libyolov8_plugins.so)."""
+
+    @staticmethod
+    def forward(
+        ctx: Graph,
+        boxes: Tensor,
+        scores: Tensor,
+        coeffs: Tensor,
+        iou_threshold: float = 0.65,
+        score_threshold: float = 0.25,
+        max_output_boxes: int = 100,
+        background_class: int = -1,
+        box_coding: int = 0,
+        plugin_version: str = "1",
+        score_activation: int = 0,
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
+        batch_size, num_boxes, num_classes = scores.shape
+        nm = coeffs.shape[-1]
+        num_dets = torch.randint(0, max_output_boxes, (batch_size, 1), dtype=torch.int32)
+        boxes = torch.randn(batch_size, max_output_boxes, 4)
+        scores = torch.randn(batch_size, max_output_boxes)
+        labels = torch.randint(0, num_classes, (batch_size, max_output_boxes), dtype=torch.int32)
+        mask_coeffs = torch.randn(batch_size, max_output_boxes, nm)
+        return num_dets, boxes, scores, labels, mask_coeffs
+
+    @staticmethod
+    def symbolic(
+        g,
+        boxes: Value,
+        scores: Value,
+        coeffs: Value,
+        iou_threshold: float = 0.65,
+        score_threshold: float = 0.25,
+        max_output_boxes: int = 100,
+        background_class: int = -1,
+        box_coding: int = 0,
+        score_activation: int = 0,
+        plugin_version: str = "1",
+    ) -> tuple[Value, Value, Value, Value, Value]:
+        out = g.op(
+            "TRT::YoloSegPostprocess",
+            boxes,
+            scores,
+            coeffs,
+            iou_threshold_f=iou_threshold,
+            score_threshold_f=score_threshold,
+            max_output_boxes_i=max_output_boxes,
+            background_class_i=background_class,
+            box_coding_i=box_coding,
+            plugin_version_s=plugin_version,
+            score_activation_i=score_activation,
+            outputs=5,
+        )
+        return out
+
+
 class C2f(nn.Module):
     def __init__(self, *args, **kwargs):
         super().__init__()
@@ -172,6 +230,10 @@ class PostSeg(nn.Module):
     export = True
     shape = None
     dynamic = False
+    iou_thres = 0.65
+    conf_thres = 0.25
+    topk = 100
+    plugin = False  # True -> emit the YoloSegPostprocess plugin (decode+NMS+coeffs in-engine)
 
     def __init__(self, *args, **kwargs):
         super().__init__()
@@ -180,11 +242,17 @@ class PostSeg(nn.Module):
         p = self.proto(x[0])  # mask protos
         bs = p.shape[0]  # batch size
         mc = torch.cat([self.cv4[i](x[i]).view(bs, self.nm, -1) for i in range(self.nl)], 2)  # mask coefficients
-        boxes, scores, labels = self.forward_det(x)
+        if self.plugin:
+            boxes, scores = self._boxes_scores(x)
+            det = TRT_YoloSeg.apply(boxes, scores, mc.transpose(1, 2), self.iou_thres, self.conf_thres, self.topk)
+            return (*det, p.flatten(2))  # num_dets, bboxes, scores, labels, mask_coeffs, proto
+        boxes, scores = self._boxes_scores(x)
+        scores, labels = scores.max(dim=-1, keepdim=True)
         out = torch.cat([boxes, scores, labels.float(), mc.transpose(1, 2)], 2)
         return out, p.flatten(2)
 
-    def forward_det(self, x):
+    # Decoded boxes [b, anchors, 4] (corner) and per-class scores [b, anchors, nc].
+    def _boxes_scores(self, x):
         shape = x[0].shape
         b, res, b_reg_num = shape[0], [], self.reg_max * 4
         for i in range(self.nl):
@@ -200,8 +268,7 @@ class PostSeg(nn.Module):
         boxes0, boxes1 = -boxes[:, :2, ...], boxes[:, 2:, ...]
         boxes = self.anchors.repeat(b, 2, 1) + torch.cat([boxes0, boxes1], 1)
         boxes = boxes * self.strides
-        scores, labels = scores.transpose(1, 2).max(dim=-1, keepdim=True)
-        return boxes.transpose(1, 2), scores, labels
+        return boxes.transpose(1, 2), scores.transpose(1, 2)
 
 
 def optim(module: nn.Module):

--- a/models/common.py
+++ b/models/common.py
@@ -69,6 +69,60 @@ class TRT_NMS(torch.autograd.Function):
         return nums_dets, boxes, scores, classes
 
 
+class TRT_YoloDet(torch.autograd.Function):
+    """Same inputs/outputs as TRT_NMS but targets our custom YoloDetPostprocess plugin
+    (libyolov8_plugins.so) instead of the built-in EfficientNMS_TRT."""
+
+    @staticmethod
+    def forward(
+        ctx: Graph,
+        boxes: Tensor,
+        scores: Tensor,
+        iou_threshold: float = 0.65,
+        score_threshold: float = 0.25,
+        max_output_boxes: int = 100,
+        background_class: int = -1,
+        box_coding: int = 0,
+        plugin_version: str = "1",
+        score_activation: int = 0,
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+        batch_size, num_boxes, num_classes = scores.shape
+        num_dets = torch.randint(0, max_output_boxes, (batch_size, 1), dtype=torch.int32)
+        boxes = torch.randn(batch_size, max_output_boxes, 4)
+        scores = torch.randn(batch_size, max_output_boxes)
+        labels = torch.randint(0, num_classes, (batch_size, max_output_boxes), dtype=torch.int32)
+        return num_dets, boxes, scores, labels
+
+    @staticmethod
+    def symbolic(
+        g,
+        boxes: Value,
+        scores: Value,
+        iou_threshold: float = 0.65,
+        score_threshold: float = 0.25,
+        max_output_boxes: int = 100,
+        background_class: int = -1,
+        box_coding: int = 0,
+        score_activation: int = 0,
+        plugin_version: str = "1",
+    ) -> tuple[Value, Value, Value, Value]:
+        out = g.op(
+            "TRT::YoloDetPostprocess",
+            boxes,
+            scores,
+            iou_threshold_f=iou_threshold,
+            score_threshold_f=score_threshold,
+            max_output_boxes_i=max_output_boxes,
+            background_class_i=background_class,
+            box_coding_i=box_coding,
+            plugin_version_s=plugin_version,
+            score_activation_i=score_activation,
+            outputs=4,
+        )
+        nums_dets, boxes, scores, classes = out
+        return nums_dets, boxes, scores, classes
+
+
 class C2f(nn.Module):
     def __init__(self, *args, **kwargs):
         super().__init__()
@@ -88,6 +142,7 @@ class PostDetect(nn.Module):
     iou_thres = 0.65
     conf_thres = 0.25
     topk = 100
+    plugin = False  # True -> emit the custom YoloDetPostprocess plugin instead of EfficientNMS_TRT
 
     def __init__(self, *args, **kwargs):
         super().__init__()
@@ -109,7 +164,8 @@ class PostDetect(nn.Module):
         boxes = self.anchors.repeat(b, 2, 1) + torch.cat([boxes0, boxes1], 1)
         boxes = boxes * self.strides
 
-        return TRT_NMS.apply(boxes.transpose(1, 2), scores.transpose(1, 2), self.iou_thres, self.conf_thres, self.topk)
+        nms = TRT_YoloDet if self.plugin else TRT_NMS
+        return nms.apply(boxes.transpose(1, 2), scores.transpose(1, 2), self.iou_thres, self.conf_thres, self.topk)
 
 
 class PostSeg(nn.Module):

--- a/models/engine.py
+++ b/models/engine.py
@@ -111,16 +111,20 @@ class EngineBuilder:
     def build_from_onnx(self, iou_thres: float = 0.65, conf_thres: float = 0.25, topk: int = 100) -> None:
         parser = trt.OnnxParser(self.network, self.logger)
         onnx_model = onnx.load(str(self.checkpoint))
-        if not self.seg:
-            # Override the NMS node's thresholds by attribute name (works for both
-            # EfficientNMS_TRT and our YoloDetPostprocess plugin, regardless of order).
-            for attr in onnx_model.graph.node[-1].attribute:
-                if attr.name == "max_output_boxes":
-                    attr.i = topk
-                elif attr.name == "score_threshold":
-                    attr.f = conf_thres
-                elif attr.name == "iou_threshold":
-                    attr.f = iou_thres
+        # Override the NMS node's thresholds by attribute name. Works for EfficientNMS_TRT
+        # and the Yolo*Postprocess plugins wherever the node sits in the graph; a no-op for
+        # raw engines that have no such node.
+        for node in onnx_model.graph.node:
+            names = {a.name for a in node.attribute}
+            if "iou_threshold" in names and "score_threshold" in names:
+                for attr in node.attribute:
+                    if attr.name == "max_output_boxes":
+                        attr.i = topk
+                    elif attr.name == "score_threshold":
+                        attr.f = conf_thres
+                    elif attr.name == "iou_threshold":
+                        attr.f = iou_thres
+                break
 
         if not parser.parse(onnx_model.SerializeToString()):
             raise RuntimeError(f"Failed to load ONNX file: {str(self.checkpoint)}")

--- a/models/engine.py
+++ b/models/engine.py
@@ -8,6 +8,7 @@ import tensorrt as trt
 import torch
 
 from models import compat
+from models.plugins import load_plugin_lib
 
 os.environ["CUDA_MODULE_LOADING"] = "LAZY"
 
@@ -44,6 +45,7 @@ class EngineBuilder:
         with_profiling: bool = True,
     ) -> None:
         logger = trt.Logger(trt.Logger.WARNING)
+        load_plugin_lib()  # register custom plugins (no-op unless YOLOV8_PLUGIN_LIB is set)
         trt.init_libnvinfer_plugins(logger, namespace="")
         builder = trt.Builder(logger)
         config = builder.create_builder_config()
@@ -110,9 +112,15 @@ class EngineBuilder:
         parser = trt.OnnxParser(self.network, self.logger)
         onnx_model = onnx.load(str(self.checkpoint))
         if not self.seg:
-            onnx_model.graph.node[-1].attribute[2].i = topk
-            onnx_model.graph.node[-1].attribute[3].f = conf_thres
-            onnx_model.graph.node[-1].attribute[4].f = iou_thres
+            # Override the NMS node's thresholds by attribute name (works for both
+            # EfficientNMS_TRT and our YoloDetPostprocess plugin, regardless of order).
+            for attr in onnx_model.graph.node[-1].attribute:
+                if attr.name == "max_output_boxes":
+                    attr.i = topk
+                elif attr.name == "score_threshold":
+                    attr.f = conf_thres
+                elif attr.name == "iou_threshold":
+                    attr.f = iou_thres
 
         if not parser.parse(onnx_model.SerializeToString()):
             raise RuntimeError(f"Failed to load ONNX file: {str(self.checkpoint)}")
@@ -213,6 +221,7 @@ class TRTModule(torch.nn.Module):
 
     def __init_engine(self) -> None:
         logger = trt.Logger(trt.Logger.WARNING)
+        load_plugin_lib()  # register custom plugins before deserialize (no-op unless YOLOV8_PLUGIN_LIB set)
         trt.init_libnvinfer_plugins(logger, namespace="")
         with trt.Runtime(logger) as runtime:
             model = runtime.deserialize_cuda_engine(self.weight.read_bytes())

--- a/models/plugins.py
+++ b/models/plugins.py
@@ -1,0 +1,20 @@
+"""Load the custom TensorRT plugin library (libyolov8_plugins.so) so its creators
+register before any engine build or deserialize. Call load_plugin_lib() ahead of
+trt.init_libnvinfer_plugins(). The path comes from the argument or the
+YOLOV8_PLUGIN_LIB env var; if neither is set this is a no-op (stock engines are
+unaffected)."""
+
+import ctypes
+import os
+
+_loaded: set[str] = set()
+
+
+def load_plugin_lib(path: str | None = None) -> None:
+    path = path or os.environ.get("YOLOV8_PLUGIN_LIB")
+    if not path or path in _loaded:
+        return
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"plugin library not found: {path}")
+    ctypes.CDLL(path, mode=ctypes.RTLD_GLOBAL)
+    _loaded.add(path)


### PR DESCRIPTION
## YoloObbPostprocess 插件（GPU 旋转 NMS via ProbIoU，自包含）

后处理插件家族最后一个。obb 经 `export-obb.py`（onnx_graphsurgeon）插桩：转置后的 raw `[1,A,C]`（C=4+nc+1：xc,yc,w,h | scores | angle）喂给 `YoloObbPostprocess`，在引擎内做**并行旋转 NMS** + top-k，输出中心框 + 角度。`obb.cpp` 按 binding 名自动识别并重建 `cv::RotatedRect`。

**旋转重叠用 ProbIoU**（协方差高斯闭式）—— ultralytics OBB 本身用的度量，比多边形相交更省、更贴近其语义。与 `ultralytics.utils.metrics.batch_probiou` **逐例 5 位小数吻合**（独立 CUDA 自测验证）。NMS 同样是 EfficientNMS 式并行（每候选一线程 + 单线程 compact）。

**验证**：bus.jpg 上插件与 raw（cv 旋转 NMS）路径在分离目标一致；build.py 阈值覆盖生效；TRT 8.6/10.16/11.0 编译。完成 det/seg/pose/obb 四类 GPU 后处理插件 + GPU 前处理 kernel。

> 栈在 #321 之上（栈尾）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
